### PR TITLE
fix: make portable seek_and_modify_string_in_file (mac OsX)

### DIFF
--- a/src/function_library/general_utilities.bash
+++ b/src/function_library/general_utilities.bash
@@ -48,7 +48,9 @@ function n2st::seek_and_modify_string_in_file() {
   local TMP_CHANGE_FOR="${2}"
   local TMP_FILE_PATH="${3}"
 
-  # Note: Character ';' is used as a delimiter
+  # Note:
+  #   - Character ';' is used as a delimiter
+  #   - Keep -i flag for portability to Mac OsX
   sudo sed -i "s;${TMP_SEEK};${TMP_CHANGE_FOR};" "${TMP_FILE_PATH}"
 
 }

--- a/src/function_library/general_utilities.bash
+++ b/src/function_library/general_utilities.bash
@@ -49,7 +49,7 @@ function n2st::seek_and_modify_string_in_file() {
   local TMP_FILE_PATH="${3}"
 
   # Note: Character ';' is used as a delimiter
-  sudo sed --in-place "s;${TMP_SEEK};${TMP_CHANGE_FOR};" "${TMP_FILE_PATH}"
+  sudo sed -i "s;${TMP_SEEK};${TMP_CHANGE_FOR};" "${TMP_FILE_PATH}"
 
 }
 


### PR DESCRIPTION
# Description
### Summary:

`n2st::seek_and_modify_string_in_file` was not portable. MacOsx implementation of `sed` does not have a `--in-place` flag. Refactor using `-i`




---

# Checklist:

### Code related
- [ ] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [ ] I have commented hard-to-understand code 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

### PR description related 
- [x] I have included a quick summary of the changes
- [x] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_
