### PR TITLE
Improvement: Enhance Script Robustness and Logging

### DIFF
--- a/import_norlab_shell_script_tools_lib.bash
+++ b/import_norlab_shell_script_tools_lib.bash
@@ -21,8 +21,7 @@ MSG_ERROR_FORMAT="\033[1;31m"
 MSG_END_FORMAT="\033[0m"
 
 function n2st::source_lib(){
-  local TMP_CWD
-  TMP_CWD=$(pwd)
+  pushd "$(pwd)" >/dev/null || exit 1
 
   # Note: can handle both sourcing cases
   #   i.e. from within a script or from an interactive terminal session
@@ -46,7 +45,7 @@ function n2st::source_lib(){
 #  PATH=$PATH:${N2ST_ROOT_DIR}/src/utility_scripts
 
   # ....Teardown...................................................................................
-  cd "${TMP_CWD}"
+  popd >/dev/null || exit 1
 }
 
 # ::::Main:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/src/function_library/teamcity_utilities.bash
+++ b/src/function_library/teamcity_utilities.bash
@@ -28,7 +28,7 @@ source ./prompt_utilities.bash
 
 # =================================================================================================
 # Check if the script is executed in JetBrains TeamCity continuous integration/deployment server
-# and set the IS_TEAMCITY_RUN environment variable accordingly
+# and set the IS_TEAMCITY_RUN environment variable accordingly, 'true' or 'false'
 #
 # Usage:
 #   $ n2st::set_is_teamcity_run_environment_variable
@@ -41,8 +41,11 @@ source ./prompt_utilities.bash
 # =================================================================================================
 function n2st::set_is_teamcity_run_environment_variable() {
   if [[ ${TEAMCITY_VERSION} ]] ; then
-    IS_TEAMCITY_RUN=true && export IS_TEAMCITY_RUN
+    IS_TEAMCITY_RUN=true
+  else
+    IS_TEAMCITY_RUN=false
   fi
+  export IS_TEAMCITY_RUN
 }
 
 

--- a/src/utility_scripts/install_docker_tools.bash
+++ b/src/utility_scripts/install_docker_tools.bash
@@ -10,6 +10,8 @@
 #   $ bash ./install_docker_tools.bash
 #
 # =================================================================================================
+pushd "$(pwd)" >/dev/null || exit 1
+
 
 # ....Pre-condition................................................................................
 if [[ "$(basename "$(pwd)")" != "utility_scripts" ]]; then
@@ -20,12 +22,14 @@ if [[ "$(basename "$(pwd)")" != "utility_scripts" ]]; then
 fi
 
 # ....Load helper function.........................................................................
-TMP_CWD=$(pwd)
+pushd "$(pwd)" >/dev/null || exit 1
 source ../../.env.n2st
 cd ../function_library || exit 1
 source ./prompt_utilities.bash
 source ./docker_utilities.bash
-cd "${TMP_CWD}"
+popd >/dev/null || exit 1
+
+
 
 # ====Begin========================================================================================
 n2st::print_formated_script_header 'install_docker_tools.bash'
@@ -75,6 +79,8 @@ echo
 
 n2st::add_user_to_the_docker_group "$(whoami)"
 
-n2st::print_formated_script_footer 'install_docker_tools.bash'
 # ====Teardown=====================================================================================
-cd "${TMP_CWD}"  || exit 1
+n2st::print_formated_script_footer 'install_docker_tools.bash'
+popd >/dev/null || exit 1
+
+

--- a/src/utility_scripts/which_architecture_and_os.bash
+++ b/src/utility_scripts/which_architecture_and_os.bash
@@ -23,6 +23,7 @@
 #   exit 1 in case of unsupported processor architecture
 #
 # =================================================================================================
+pushd "$(pwd)" >/dev/null || exit 1
 
 # ....Pre-condition................................................................................
 if [[ "$(basename "$(pwd)")" != "utility_scripts" ]]; then
@@ -33,8 +34,6 @@ if [[ "$(basename "$(pwd)")" != "utility_scripts" ]]; then
 fi
 
 # ....Load helper function.........................................................................
-TMP_CWD=$(pwd)
-
 # (Priority) ToDo: validate!! (ref task NMO-388 fix: explicitly sourcing .env.n2st cause conflicting problem when the repo is used as a lib)
 if [[ -z $PROJECT_PROMPT_NAME ]] && [[ -z $PROJECT_GIT_NAME ]] ; then
   set -o allexport
@@ -45,8 +44,9 @@ fi
 cd ../function_library || exit 1
 source ./general_utilities.bash
 
-cd "${TMP_CWD}"
 
 # ====Begin========================================================================================
 n2st::set_which_architecture_and_os
 
+# ====Teardown=====================================================================================
+popd >/dev/null || exit 1

--- a/src/utility_scripts/which_python_version.bash
+++ b/src/utility_scripts/which_python_version.bash
@@ -13,7 +13,7 @@
 #   write 'PYTHON3_VERSION'
 #
 # =================================================================================================
-
+pushd "$(pwd)" >/dev/null || exit 1
 
 # ....Pre-condition................................................................................
 if [[ "$(basename "$(pwd)")" != "utility_scripts" ]]; then
@@ -24,7 +24,6 @@ if [[ "$(basename "$(pwd)")" != "utility_scripts" ]]; then
 fi
 
 # ....Load helper function.........................................................................
-TMP_CWD=$(pwd)
 
 # (Priority) ToDo: validate!! (ref task NMO-388 fix: explicitly sourcing .env.n2st cause conflicting problem when the repo is used as a lib)
 if [[ -z $PROJECT_PROMPT_NAME ]] && [[ -z $PROJECT_GIT_NAME ]] ; then
@@ -36,8 +35,8 @@ fi
 cd ../function_library || exit 1
 source ./general_utilities.bash
 
-cd "${TMP_CWD}"
-
 # ====Begin========================================================================================
 n2st::set_which_python3_version
 
+# ====Teardown=====================================================================================
+popd >/dev/null || exit 1

--- a/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.alpine
+++ b/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.alpine
@@ -10,7 +10,16 @@ ENV N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH=${N2ST_BATS_TESTING_TOOLS_RELATIVE_PAT
 ARG TEAMCITY_VERSION
 ENV TEAMCITY_VERSION=${TEAMCITY_VERSION}
 
+# (Priority) ToDo: implement >> next bloc ↓↓ (ref task NMO-570)
+ARG N2ST_VERSION
+LABEL norlab.tools.norlab-shell-script-tools.tester="${N2ST_VERSION:?err}"
+LABEL org.opencontainers.image.authors="luc.coupal.1@ulaval.ca"
+
+SHELL ["/bin/bash", "-e", "-c"]
+ARG DEBIAN_FRONTEND=noninteractive
+
 ENV TERM=${TERM:-"xterm-256color"}
+ENV COLUMNS=80
 
 # Note:
 #   Image purpose › source code isolation for CI build

--- a/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.ubuntu
+++ b/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.ubuntu
@@ -2,9 +2,9 @@
 #   Image purpose › source code isolation for CI build
 #   This container use a copy project source code strategy instead of using the mounting volume
 
-FROM bats/bats:latest as bats-core-base-img
+FROM bats/bats:latest AS bats-core-base-img
 
-FROM ubuntu:latest as final
+FROM ubuntu:latest AS final
 
 ARG CONTAINER_PROJECT_ROOT_NAME
 ENV CONTAINER_PROJECT_ROOT_NAME=${CONTAINER_PROJECT_ROOT_NAME:?'Build argument needs to be set and non-empty.'}
@@ -16,13 +16,14 @@ ENV N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH=${N2ST_BATS_TESTING_TOOLS_RELATIVE_PAT
 ARG TEAMCITY_VERSION
 ENV TEAMCITY_VERSION=${TEAMCITY_VERSION}
 
+ARG N2ST_VERSION
+LABEL norlab.tools.norlab-shell-script-tools.tester="${N2ST_VERSION:?err}"
 LABEL org.opencontainers.image.authors="luc.coupal.1@ulaval.ca"
 
 SHELL ["/bin/bash", "-e", "-c"]
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV TERM=${TERM:-"xterm-256color"}
-#RUN tput -T $TERM init
 ENV COLUMNS=80
 
 # ====Begin========================================================================================

--- a/tests/bats_testing_tools/run_bats_tests_in_docker.bash
+++ b/tests/bats_testing_tools/run_bats_tests_in_docker.bash
@@ -20,13 +20,7 @@ BATS_DOCKERFILE_DISTRO=${2:-'ubuntu'}
 ## Set Docker builder log output for debug. Options: plain, tty or auto (default)
 #export BUILDKIT_PROGRESS=plain
 
-# ====Begin========================================================================================
-
-# ....Project root logic...........................................................................
-PROJECT_CLONE_GIT_ROOT=$(git rev-parse --show-toplevel)
-PROJECT_CLONE_GIT_NAME=$(basename "$PROJECT_CLONE_GIT_ROOT" .git)
-PROJECT_GIT_REMOTE_URL=$(git remote get-url origin)
-PROJECT_GIT_NAME=$(basename "${PROJECT_GIT_REMOTE_URL}" .git)
+# ....N2ST root logic..............................................................................
 REPO_ROOT=$(pwd)
 N2ST_BATS_TESTING_TOOLS_ABS_PATH="$( cd "$( dirname "${0}" )" &> /dev/null && pwd )"
 
@@ -34,13 +28,24 @@ N2ST_BATS_TESTING_TOOLS_ABS_PATH="$( cd "$( dirname "${0}" )" &> /dev/null && pw
 #N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH=".${N2ST_BATS_TESTING_TOOLS_ABS_PATH/$REPO_ROOT/}"
 N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH="tests/bats_testing_tools"
 
-N2ST_PATH=$( git rev-parse --show-toplevel )
-#N2ST_PATH="${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}/../.."
+#N2ST_PATH=$( git rev-parse --show-toplevel )
+N2ST_PATH="${N2ST_BATS_TESTING_TOOLS_ABS_PATH}/../.."
 test -d "${N2ST_PATH}" || exit 1
 #tree -a -L 1 ${N2ST_PATH}
 N2ST_VERSION="$(cat "${N2ST_PATH}"/version.txt)"
 
+# ....Source project shell-scripts dependencies....................................................
+pushd "$(pwd)" >/dev/null || exit 1
+source "${N2ST_PATH}"/import_norlab_shell_script_tools_lib.bash || exit 1
+popd >/dev/null || exit 1
 
+# ....Project root logic...........................................................................
+PROJECT_CLONE_GIT_ROOT=$(git rev-parse --show-toplevel)
+PROJECT_CLONE_GIT_NAME=$(basename "$PROJECT_CLONE_GIT_ROOT" .git)
+PROJECT_GIT_REMOTE_URL=$(git remote get-url origin)
+PROJECT_GIT_NAME=$(basename "${PROJECT_GIT_REMOTE_URL}" .git)
+
+# ....Pre-condition................................................................................
 if [[ $(basename "$REPO_ROOT") != ${PROJECT_CLONE_GIT_NAME} ]]; then
   echo -e "\n[\033[1;31mERROR\033[0m] $0 must be executed from the project root!\nCurrent wordir: $(pwd)" 1>&2
   echo '(press any key to exit)'
@@ -51,15 +56,41 @@ fi
 test -d "${N2ST_BATS_TESTING_TOOLS_ABS_PATH}" || exit 1
 test -f "${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}/bats_helper_functions.bash" ||  exit 1
 
-# Do not load MSG_BASE nor MSG_BASE_TEAMCITY from there .env file so that tested logic does not leak in that file
-_MSG_BASE="\033[1m[${PROJECT_GIT_NAME}]\033[0m"
-_MSG_BASE_TEAMCITY="|[${PROJECT_GIT_NAME}|]"
+# //// DEV ////////////////////////////////////////////////////////////////////////////////////////
 
+
+n2st::norlab_splash "${PROJECT_PROMPT_NAME}" "${PROJECT_GIT_REMOTE_URL}"
+n2st::print_formated_script_header "$(basename $0) ${MSG_END_FORMAT}on device ${MSG_DIMMED_FORMAT}$(hostname -s)" "${MSG_LINE_CHAR_BUILDER_LVL2}"
+
+n2st::set_is_teamcity_run_environment_variable
+n2st::print_msg "IS_TEAMCITY_RUN=${IS_TEAMCITY_RUN} ${TC_VERSION}"
+if [[ ${IS_TEAMCITY_RUN} != true ]] && [[ -z ${BUILDX_BUILDER} ]]; then
+  # Note: Default to default buildx builder (ie native host architecture) so that the build img
+  # be available in the local image store and that run executed via `up_and_attach.bash` doesn't
+  # require pulling built img from dockerhub.
+  n2st::set_which_architecture_and_os
+  n2st::print_msg "Current image architecture and os: $IMAGE_ARCH_AND_OS"
+  if [[ $IMAGE_ARCH_AND_OS == 'darwin/arm64' ]]; then
+    export BUILDX_BUILDER=desktop-linux
+  else
+    export BUILDX_BUILDER=default
+  fi
+  n2st::print_msg "Setting BUILDX_BUILDER=$BUILDX_BUILDER"
+  # Force builder initialisation
+  docker buildx inspect --bootstrap $BUILDX_BUILDER >/dev/null
+fi
+# \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ DEV \\\\
+
+# ====Begin========================================================================================
 # ....Execute docker steps.........................................................................
 # Note:
 #   - CONTAINER_PROJECT_ROOT_NAME is for copying the source code including the repository root (i.e.: the project name)
 #   - BUILDKIT_CONTEXT_KEEP_GIT_DIR is for setting buildkit to keep the .git directory in the container
 #     Source https://docs.docker.com/build/building/context/#keep-git-directory
+
+# Do not load MSG_BASE nor MSG_BASE_TEAMCITY from there .env file so that tested logic does not leak in that file
+_MSG_BASE="\033[1m[${PROJECT_GIT_NAME}]\033[0m"
+_MSG_BASE_TEAMCITY="|[${PROJECT_GIT_NAME}|]"
 
 if [[ ${TEAMCITY_VERSION} ]]; then
   echo -e "##teamcity[blockOpened name='${_MSG_BASE_TEAMCITY} Build custom bats-core docker image']"

--- a/tests/bats_testing_tools/run_bats_tests_in_docker.bash
+++ b/tests/bats_testing_tools/run_bats_tests_in_docker.bash
@@ -57,12 +57,16 @@ test -d "${N2ST_BATS_TESTING_TOOLS_ABS_PATH}" || exit 1
 test -f "${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}/bats_helper_functions.bash" ||  exit 1
 
 # ====Begin========================================================================================
-n2st::norlab_splash "${PROJECT_PROMPT_NAME}" "${PROJECT_GIT_REMOTE_URL}"
+n2st::set_is_teamcity_run_environment_variable
+n2st::print_msg "IS_TEAMCITY_RUN=${IS_TEAMCITY_RUN} ${TC_VERSION}"
+if [[ ${IS_TEAMCITY_RUN} != true ]] && [[ -z ${BUILDX_BUILDER} ]]; then
+  n2st::norlab_splash "${PROJECT_PROMPT_NAME}" "${PROJECT_GIT_REMOTE_URL}"
+fi
 n2st::print_formated_script_header "$(basename $0) ${MSG_END_FORMAT}on device ${MSG_DIMMED_FORMAT}$(hostname -s)" "${MSG_LINE_CHAR_BUILDER_LVL2}"
 
 if [[ -z ${BUILDX_BUILDER} ]]; then
   # Note: Default to default buildx builder (ie native host architecture) so that the build img
-  # be available in the local image store and that run executed via `up_and_attach.bash` doesn't
+  # be available in the local image store and that tests executed via docker run doesn't
   # require pulling built img from dockerhub.
   n2st::set_which_architecture_and_os
   n2st::print_msg "Current image architecture and os: $IMAGE_ARCH_AND_OS"

--- a/tests/bats_testing_tools/run_bats_tests_in_docker.bash
+++ b/tests/bats_testing_tools/run_bats_tests_in_docker.bash
@@ -56,15 +56,11 @@ fi
 test -d "${N2ST_BATS_TESTING_TOOLS_ABS_PATH}" || exit 1
 test -f "${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}/bats_helper_functions.bash" ||  exit 1
 
-# //// DEV ////////////////////////////////////////////////////////////////////////////////////////
-
-
+# ====Begin========================================================================================
 n2st::norlab_splash "${PROJECT_PROMPT_NAME}" "${PROJECT_GIT_REMOTE_URL}"
 n2st::print_formated_script_header "$(basename $0) ${MSG_END_FORMAT}on device ${MSG_DIMMED_FORMAT}$(hostname -s)" "${MSG_LINE_CHAR_BUILDER_LVL2}"
 
-n2st::set_is_teamcity_run_environment_variable
-n2st::print_msg "IS_TEAMCITY_RUN=${IS_TEAMCITY_RUN} ${TC_VERSION}"
-if [[ ${IS_TEAMCITY_RUN} != true ]] && [[ -z ${BUILDX_BUILDER} ]]; then
+if [[ -z ${BUILDX_BUILDER} ]]; then
   # Note: Default to default buildx builder (ie native host architecture) so that the build img
   # be available in the local image store and that run executed via `up_and_attach.bash` doesn't
   # require pulling built img from dockerhub.
@@ -79,9 +75,7 @@ if [[ ${IS_TEAMCITY_RUN} != true ]] && [[ -z ${BUILDX_BUILDER} ]]; then
   # Force builder initialisation
   docker buildx inspect --bootstrap $BUILDX_BUILDER >/dev/null
 fi
-# \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ DEV \\\\
 
-# ====Begin========================================================================================
 # ....Execute docker steps.........................................................................
 # Note:
 #   - CONTAINER_PROJECT_ROOT_NAME is for copying the source code including the repository root (i.e.: the project name)

--- a/tests/test_dotenv_files.bats
+++ b/tests/test_dotenv_files.bats
@@ -261,6 +261,7 @@ function source_dotenv_project() {
   cd ..
   assert_equal "$(pwd)" "/code"
 
+
   git clone "https://github.com/norlab-ulaval/${SUPERPROJECT_NAME}.git"
   assert_dir_exist "${SUPERPROJECT_NAME}"
 

--- a/tests/test_teamcity_utilities.bats
+++ b/tests/test_teamcity_utilities.bats
@@ -78,6 +78,18 @@ teardown() {
 }
 
 @test "n2st::set_is_teamcity_run_environment_variable ok" {
+
+  # Case › not run in TeamCity
+  run n2st::set_is_teamcity_run_environment_variable
+  assert_success
+  n2st::set_is_teamcity_run_environment_variable
+  assert_not_empty  "$IS_TEAMCITY_RUN"
+
+  # Reset state
+  unset IS_TEAMCITY_RUN
+  assert_empty "$IS_TEAMCITY_RUN"
+
+  # Case › run in TeamCity
   fake_IS_TEAMCITY_RUN
   run n2st::set_is_teamcity_run_environment_variable
   assert_success

--- a/tests/tests_template/run_bats_core_test_in_n2st.bash
+++ b/tests/tests_template/run_bats_core_test_in_n2st.bash
@@ -29,8 +29,7 @@ fi
 
 
 function n2st::run_n2st_testsing_tools(){
-  local TMP_CWD
-  TMP_CWD=$(pwd)
+  pushd "$(pwd)" >/dev/null || exit 1
 
   # ....Project root logic.........................................................................
   SUPERPROJECT_PATH=$(git rev-parse --show-toplevel)
@@ -43,7 +42,7 @@ function n2st::run_n2st_testsing_tools(){
   bash "${N2ST_PATH}/tests/bats_testing_tools/run_bats_tests_in_docker.bash" $PARAMS
 
   # ....Teardown...................................................................................
-  cd "$TMP_CWD"
+  popd >/dev/null || exit 1
   }
 
 n2st::run_n2st_testsing_tools


### PR DESCRIPTION
# Description
### Summary:

This pull request includes the following updates:

- **Fix: Script Robustness and logging improvement in multiple utility scripts** \
Improved the resilience and logging features in various utility scripts to deliver a better user experience and debug information. Also added a new image label particular to n2st. The related issues for these updates are <issue id> NMO-571, NMO-550, NMO-559, NMO-560, NMO-570.

- **Continuous Integration: Rollback on Conventional Changelog Conventionalcommits plugin** \
Addressed some issues with the Conventional Changelog Conventionalcommits plugin by performing a temporary rollback to ensure stable build conditions.

- **Bug Fixes and Continuous Integration** \
Multiple bugs were addressed including the removal of development comments, setting the terminal tput COLUMNS width explicitly, showing console print on CI, and temporarily displaying CI terminal TERM. An issue with semantic-release/conventional-changelog-conventionalcommits release v8 was tackled with a quick fix. The related issue for the bug fixes was <issue id> NMO-546.

- **Fix: Console Centering Related Error** \
Resolved a function related error with prompt center that was originating from the CI. This fix is relevant to the issue <issue id> NMO-546.

---

# Checklist:

### Code related
- [x] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [x] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

### PR description related 
- [x] I have included a quick summary of the changes
- [x] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_
