### PR TITLE
Fix: Handle Relative Path from Parent Call to run_bats_tests_in_docker.bash

### DIFF
--- a/import_norlab_shell_script_tools_lib.bash
+++ b/import_norlab_shell_script_tools_lib.bash
@@ -44,6 +44,9 @@ function n2st::source_lib(){
 #  cd "${N2ST_ROOT_DIR}/src/utility_scripts"
 #  PATH=$PATH:${N2ST_ROOT_DIR}/src/utility_scripts
 
+  N2ST_VERSION="$(cat "${N2ST_PATH}"/version.txt)"
+  export N2ST_VERSION
+
   # ....Teardown...................................................................................
   popd >/dev/null || exit 1
 }

--- a/tests/bats_testing_tools/run_bats_tests_in_docker.bash
+++ b/tests/bats_testing_tools/run_bats_tests_in_docker.bash
@@ -24,16 +24,10 @@ BATS_DOCKERFILE_DISTRO=${2:-'ubuntu'}
 # ....N2ST root logic..............................................................................
 REPO_ROOT=$(pwd)
 N2ST_BATS_TESTING_TOOLS_ABS_PATH="$( cd "$( dirname "${0}" )" &> /dev/null && pwd )"
-
-# ToDo: assessment › harccoding the relative path is more robust. Since the location wont change anymore, the version with string substitution is irelevant.
 N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH=".${N2ST_BATS_TESTING_TOOLS_ABS_PATH/$REPO_ROOT/}"
-#N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH="tests/bats_testing_tools"
 
-#N2ST_PATH=$( git rev-parse --show-toplevel )
 N2ST_PATH="${N2ST_BATS_TESTING_TOOLS_ABS_PATH}/../.."
 test -d "${N2ST_PATH}" || exit 1
-#tree -a -L 1 ${N2ST_PATH}
-
 
 # ....Source project shell-scripts dependencies....................................................
 pushd "$(pwd)" >/dev/null || exit 1

--- a/tests/bats_testing_tools/run_bats_tests_in_docker.bash
+++ b/tests/bats_testing_tools/run_bats_tests_in_docker.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
-#
+# =================================================================================================
 # Execute bats unit test in a docker container with bats-core support including several helper libraries
 #
 # Usage:
@@ -12,6 +12,7 @@
 #                                                      run all bats file in the test directory
 #   - ['<image-distro>']          ubuntu or alpine (default ubuntu)
 #
+# =================================================================================================
 
 RUN_TESTS_IN_DIR=${1:-'tests'}
 BATS_DOCKERFILE_DISTRO=${2:-'ubuntu'}
@@ -25,14 +26,14 @@ REPO_ROOT=$(pwd)
 N2ST_BATS_TESTING_TOOLS_ABS_PATH="$( cd "$( dirname "${0}" )" &> /dev/null && pwd )"
 
 # ToDo: assessment › harccoding the relative path is more robust. Since the location wont change anymore, the version with string substitution is irelevant.
-#N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH=".${N2ST_BATS_TESTING_TOOLS_ABS_PATH/$REPO_ROOT/}"
-N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH="tests/bats_testing_tools"
+N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH=".${N2ST_BATS_TESTING_TOOLS_ABS_PATH/$REPO_ROOT/}"
+#N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH="tests/bats_testing_tools"
 
 #N2ST_PATH=$( git rev-parse --show-toplevel )
 N2ST_PATH="${N2ST_BATS_TESTING_TOOLS_ABS_PATH}/../.."
 test -d "${N2ST_PATH}" || exit 1
 #tree -a -L 1 ${N2ST_PATH}
-N2ST_VERSION="$(cat "${N2ST_PATH}"/version.txt)"
+
 
 # ....Source project shell-scripts dependencies....................................................
 pushd "$(pwd)" >/dev/null || exit 1
@@ -58,12 +59,12 @@ test -f "${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}/bats_helper_functions.bash" ||
 
 # ====Begin========================================================================================
 n2st::set_is_teamcity_run_environment_variable
-n2st::print_msg "IS_TEAMCITY_RUN=${IS_TEAMCITY_RUN} ${TC_VERSION}"
 if [[ ${IS_TEAMCITY_RUN} != true ]] && [[ -z ${BUILDX_BUILDER} ]]; then
   n2st::norlab_splash "${PROJECT_PROMPT_NAME}" "${PROJECT_GIT_REMOTE_URL}"
 fi
 n2st::print_formated_script_header "$(basename $0) ${MSG_END_FORMAT}on device ${MSG_DIMMED_FORMAT}$(hostname -s)" "${MSG_LINE_CHAR_BUILDER_LVL2}"
 
+n2st::print_msg "IS_TEAMCITY_RUN=${IS_TEAMCITY_RUN} ${TC_VERSION}"
 if [[ -z ${BUILDX_BUILDER} ]]; then
   # Note: Default to default buildx builder (ie native host architecture) so that the build img
   # be available in the local image store and that tests executed via docker run doesn't


### PR DESCRIPTION
# Description
### Summary:

- The variable initialization for N2ST_VERSION has been migrated to a common script. This change aligns with the best coding practices of defining and initializing variables in a common area.
- The TeamCity environment message logging sequence has been reorganized for better clarity and log tracking. (This addresses issue NMO-571)
- Adds visual separators in the script for enhanced readability.
---

# Checklist:

### Code related
- [ ] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [ ] I have commented hard-to-understand code 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [ ] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [ ] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [ ] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

### PR description related 
- [ ] I have included a quick summary of the changes
- [ ] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_
