### PR TITLE
Refactoring and modifications to prompt and splash functionality

### DIFF
--- a/src/function_library/prompt_utilities.bash
+++ b/src/function_library/prompt_utilities.bash
@@ -136,13 +136,13 @@ function n2st::draw_horizontal_line_across_the_terminal_window() {
   local pad
 
   # Ref https://bash.cyberciti.biz/guide/$TERM_variable
-  TPUT_FLAG="-T $TERM"
+  TPUT_FLAG=("-T" "$TERM")
   if [[ -z ${TERM} ]]; then
-    TPUT_FLAG='-T xterm-256color'
+    TPUT_FLAG=("-T" "xterm-256color")
   elif [[ ${TERM} == dumb ]]; then
     # "dumb" is the one set on TeamCity Agent
-#    TPUT_FLAG='-T xterm-256color'
-    unset TPUT_FLAG
+    TPUT_FLAG=("-T" "xterm-256color")
+#    unset TPUT_FLAG
   fi
 
   # (NICE TO HAVE) ToDo:
@@ -154,9 +154,10 @@ function n2st::draw_horizontal_line_across_the_terminal_window() {
 
   # Alt version
   # shellcheck disable=SC2086
-  terminal_width="${COLUMNS:-$(tput ${TPUT_FLAG} cols)}"
-  pad=$(printf -- "${SYMBOL}%.0s" $(seq $terminal_width))
+  terminal_width="${COLUMNS:-$(tput "${TPUT_FLAG[@]}" cols)}"
+  pad=$(printf -- "${SYMBOL}%.0s" $(seq "${terminal_width}"))
   printf -- "${pad}\n"
+#  printf -- "%\n" "${pad}"
 
 #  # (CRITICAL) ToDo: on task end >> delete next bloc ↓↓
 #  echo "terminal_width=${terminal_width}"

--- a/src/function_library/terminal_splash.bash
+++ b/src/function_library/terminal_splash.bash
@@ -46,14 +46,15 @@ function n2st::echo_centering_str() {
   fi
 
   # Ref https://bash.cyberciti.biz/guide/$TERM_variable
-  TPUT_FLAG="-T ${TERM}"
+  TPUT_FLAG=("-T" "$TERM")
   if [[ -z ${TERM} ]]; then
-    TPUT_FLAG='-T xterm-256color'
+    TPUT_FLAG=("-T" "xterm-256color")
   elif [[ ${TERM} == dumb ]]; then
     # "dumb" is the one set on TeamCity Agent
-#    TPUT_FLAG='-T xterm-256color'
-    unset TPUT_FLAG
+    TPUT_FLAG=("-T" "xterm-256color")
+#    unset TPUT_FLAG
   fi
+
 
   # (NICE TO HAVE) ToDo:
   #     - var TERM should be setup in Dockerfile.dependencies.
@@ -62,9 +63,9 @@ function n2st::echo_centering_str() {
   local terminal_width
 #  terminal_width=$(tput ${TPUT_FLAG} cols)
   # shellcheck disable=SC2086
-  terminal_width="${COLUMNS:-$(tput ${TPUT_FLAG} cols)}"
-  local total_padding_len=$(( $terminal_width - $str_len ))
-  local single_side_padding_len=$(( $total_padding_len / 2 ))
+  terminal_width="${COLUMNS:-$(tput "${TPUT_FLAG[@]}" cols)}"
+  local total_padding_len=$(( ${terminal_width} - ${str_len} ))
+  local single_side_padding_len=$(( ${total_padding_len} / 2 ))
   local pad
   pad=$(printf -- "$the_pad_cha%.0s" $(seq $single_side_padding_len))
   LC_ALL='' LC_CTYPE=en_US.UTF-8 printf -- "%b%b%s%b%s%b%b\n" "${the_style}" "${fill_left}" "${pad}" "${the_str}" "${pad}" "${fill_right}" "${the_style_off}"

--- a/src/utility_scripts/install_docker_tools.bash
+++ b/src/utility_scripts/install_docker_tools.bash
@@ -10,7 +10,6 @@
 #   $ bash ./install_docker_tools.bash
 #
 # =================================================================================================
-pushd "$(pwd)" >/dev/null || exit 1
 
 
 # ....Pre-condition................................................................................
@@ -22,6 +21,8 @@ if [[ "$(basename "$(pwd)")" != "utility_scripts" ]]; then
 fi
 
 # ....Load helper function.........................................................................
+pushd "$(pwd)" >/dev/null || exit 1
+
 pushd "$(pwd)" >/dev/null || exit 1
 source ../../.env.n2st
 cd ../function_library || exit 1

--- a/src/utility_scripts/which_architecture_and_os.bash
+++ b/src/utility_scripts/which_architecture_and_os.bash
@@ -23,7 +23,6 @@
 #   exit 1 in case of unsupported processor architecture
 #
 # =================================================================================================
-pushd "$(pwd)" >/dev/null || exit 1
 
 # ....Pre-condition................................................................................
 if [[ "$(basename "$(pwd)")" != "utility_scripts" ]]; then
@@ -34,6 +33,8 @@ if [[ "$(basename "$(pwd)")" != "utility_scripts" ]]; then
 fi
 
 # ....Load helper function.........................................................................
+pushd "$(pwd)" >/dev/null || exit 1
+
 # (Priority) ToDo: validate!! (ref task NMO-388 fix: explicitly sourcing .env.n2st cause conflicting problem when the repo is used as a lib)
 if [[ -z $PROJECT_PROMPT_NAME ]] && [[ -z $PROJECT_GIT_NAME ]] ; then
   set -o allexport

--- a/src/utility_scripts/which_python_version.bash
+++ b/src/utility_scripts/which_python_version.bash
@@ -13,7 +13,6 @@
 #   write 'PYTHON3_VERSION'
 #
 # =================================================================================================
-pushd "$(pwd)" >/dev/null || exit 1
 
 # ....Pre-condition................................................................................
 if [[ "$(basename "$(pwd)")" != "utility_scripts" ]]; then
@@ -24,6 +23,7 @@ if [[ "$(basename "$(pwd)")" != "utility_scripts" ]]; then
 fi
 
 # ....Load helper function.........................................................................
+pushd "$(pwd)" >/dev/null || exit 1
 
 # (Priority) ToDo: validate!! (ref task NMO-388 fix: explicitly sourcing .env.n2st cause conflicting problem when the repo is used as a lib)
 if [[ -z $PROJECT_PROMPT_NAME ]] && [[ -z $PROJECT_GIT_NAME ]] ; then

--- a/tests/bats_testing_tools/run_bats_tests_in_docker.bash
+++ b/tests/bats_testing_tools/run_bats_tests_in_docker.bash
@@ -53,9 +53,7 @@ test -f "${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}/bats_helper_functions.bash" ||
 
 # ====Begin========================================================================================
 n2st::set_is_teamcity_run_environment_variable
-if [[ ${IS_TEAMCITY_RUN} != true ]] && [[ -z ${BUILDX_BUILDER} ]]; then
-  n2st::norlab_splash "${PROJECT_PROMPT_NAME}" "${PROJECT_GIT_REMOTE_URL}"
-fi
+n2st::norlab_splash "${PROJECT_PROMPT_NAME}" "${PROJECT_GIT_REMOTE_URL}"
 n2st::print_formated_script_header "$(basename $0) ${MSG_END_FORMAT}on device ${MSG_DIMMED_FORMAT}$(hostname -s)" "${MSG_LINE_CHAR_BUILDER_LVL2}"
 
 n2st::print_msg "IS_TEAMCITY_RUN=${IS_TEAMCITY_RUN} ${TC_VERSION}"


### PR DESCRIPTION
# Description
### Summary:

#### Revert: Re-enable splash in TeamCity run

In the run_bats_tests_in_docker.bash file, a modification has been made to return the re-enabled splash screen for TeamCity runs. This was done for usability and visibility enhancements.

#### Refactor: Modify TPUT_FLAG assignment and reorganize pushd ([Issue NMO-388](https://norlab.youtrack.cloud/issue/NMO-388))

Adjustments to the `TPUT_FLAG` variable in the way it is assigned and formatted have been made in the `terminal_splash.bash`. We are now utilizing an array format, improving code versatility and extending capabilities. In order to improve script structure, reorganization of the pushd command was performed.

#### Refactor: Modify TPUT_FLAG assignment and reorganize pushd ([Issue NMO-388](https://norlab.youtrack.cloud/issue/NMO-388))

The `TPUT_FLAG` assignment has been modified in the `prompt_utilities.bash` as well, employing similar changes as in `terminal_splash.bash`. Additionally, some unnecessary `pushd` commands have been removed in the utility scripts for the sake of code decluttering. Debug print statements have been commented out in `prompt_utilities.bash` for cleaner code execution.

---

# Checklist:

### Code related
- [x] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [x] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

### PR description related 
- [x] I have included a quick summary of the changes
- [x] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_
