### PR TITLE
Refactoring and Enhancement of Directory Handling and Error Messages in Import Lib Script 

### DIFF
--- a/import_norlab_shell_script_tools_lib.bash
+++ b/import_norlab_shell_script_tools_lib.bash
@@ -20,8 +20,13 @@ MSG_DIMMED_FORMAT="\033[1;2m"
 MSG_ERROR_FORMAT="\033[1;31m"
 MSG_END_FORMAT="\033[0m"
 
-function n2st::source_lib(){
-  pushd "$(pwd)" >/dev/null || { echo "pushd error"  1>&2 && exit 1;}
+function n2st::source_lib() {
+
+  # ....Setup......................................................................................
+  # Note: Use local var approach for dir handling in lib import script has its more robust in case
+  #       of nested error (instead of the pushd approach).
+  local TMP_CWD
+  TMP_CWD=$(pwd)
 
   # Note: can handle both sourcing cases
   #   i.e. from within a script or from an interactive terminal session
@@ -29,35 +34,34 @@ function n2st::source_lib(){
   _REPO_ROOT="$(dirname "${_PATH_TO_SCRIPT}")"
 
   # ....Load environment variables from file.......................................................
-  cd "${_REPO_ROOT}" || { echo "${_REPO_ROOT} unreachable"  1>&2 && exit 1;}
+  cd "${_REPO_ROOT}" || { echo "${_REPO_ROOT} unreachable" 1>&2 && exit 1; }
   set -o allexport
   source .env.n2st
   set +o allexport
 
   # ....Begin......................................................................................
-  cd "${N2ST_PATH:?'[ERROR] env var not set!'}/src/function_library" || { echo "${N2ST_PATH} unreachable"  1>&2 && exit 1;}
-  for each_file in "$(pwd)"/*.bash ; do
-      source "${each_file}" || { echo "${each_file} unexpected error"  1>&2 && exit 1;}
+  cd "${N2ST_PATH:?'[ERROR] env var not set!'}/src/function_library" || { echo "${N2ST_PATH} unreachable" 1>&2 && exit 1; }
+  for each_file in "$(pwd)"/*.bash; do
+    source "${each_file}" || { echo "${each_file} unexpected error" 1>&2 && exit 1; }
   done
 
   # (NICE TO HAVE) ToDo: append lib to PATH (ref task NMO-414)
-#  cd "${N2ST_ROOT_DIR}/src/utility_scripts"
-#  PATH=$PATH:${N2ST_ROOT_DIR}/src/utility_scripts
+  #  cd "${N2ST_ROOT_DIR}/src/utility_scripts"
+  #  PATH=$PATH:${N2ST_ROOT_DIR}/src/utility_scripts
 
   N2ST_VERSION="$(cat "${N2ST_PATH}"/version.txt)"
   export N2ST_VERSION
 
   # ....Teardown...................................................................................
-  popd >/dev/null || { echo "popd error"  1>&2 && exit 1;}
+  cd "${TMP_CWD}" || { echo "Return to original dir error" 1>&2 && exit 1; }
 }
 
 # ::::Main:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
   # This script is being run, ie: __name__="__main__"
-  echo -e "${MSG_ERROR_FORMAT}[ERROR]${MSG_END_FORMAT} This script must be sourced i.e.: $ source $( basename "$0" )" 1>&2
+  echo -e "${MSG_ERROR_FORMAT}[ERROR]${MSG_END_FORMAT} This script must be sourced i.e.: $ source $(basename "$0")" 1>&2
   exit 1
 else
   # This script is being sourced, ie: __name__="__source__"
   n2st::source_lib
 fi
-

--- a/import_norlab_shell_script_tools_lib.bash
+++ b/import_norlab_shell_script_tools_lib.bash
@@ -21,7 +21,7 @@ MSG_ERROR_FORMAT="\033[1;31m"
 MSG_END_FORMAT="\033[0m"
 
 function n2st::source_lib(){
-  pushd "$(pwd)" >/dev/null || exit 1
+  pushd "$(pwd)" >/dev/null || { echo "pushd error"  1>&2 && exit 1;}
 
   # Note: can handle both sourcing cases
   #   i.e. from within a script or from an interactive terminal session
@@ -29,15 +29,15 @@ function n2st::source_lib(){
   _REPO_ROOT="$(dirname "${_PATH_TO_SCRIPT}")"
 
   # ....Load environment variables from file.......................................................
-  cd "${_REPO_ROOT}" || exit 1
+  cd "${_REPO_ROOT}" || { echo "${_REPO_ROOT} unreachable"  1>&2 && exit 1;}
   set -o allexport
   source .env.n2st
   set +o allexport
 
   # ....Begin......................................................................................
-  cd "${N2ST_PATH:?'[ERROR] env var not set!'}/src/function_library" || exit 1
+  cd "${N2ST_PATH:?'[ERROR] env var not set!'}/src/function_library" || { echo "${N2ST_PATH} unreachable"  1>&2 && exit 1;}
   for each_file in "$(pwd)"/*.bash ; do
-      source "${each_file}"
+      source "${each_file}" || { echo "${each_file} unexpected error"  1>&2 && exit 1;}
   done
 
   # (NICE TO HAVE) ToDo: append lib to PATH (ref task NMO-414)
@@ -48,7 +48,7 @@ function n2st::source_lib(){
   export N2ST_VERSION
 
   # ....Teardown...................................................................................
-  popd >/dev/null || exit 1
+  popd >/dev/null || { echo "popd error"  1>&2 && exit 1;}
 }
 
 # ::::Main:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/tests/test_import_lib.bats
+++ b/tests/test_import_lib.bats
@@ -83,6 +83,7 @@ teardown() {
   assert_empty ${N2ST_GIT_NAME}
   assert_empty ${N2ST_SRC_NAME}
   assert_empty ${N2ST_PATH}
+  assert_empty ${N2ST_VERSION}
 
   # ....Import N2ST library........................................................................
   source "$TESTED_FILE"
@@ -99,6 +100,7 @@ teardown() {
   assert_equal "${N2ST_GIT_NAME}" "norlab-shell-script-tools"
   assert_equal "${N2ST_SRC_NAME}" "norlab-shell-script-tools"
   assert_equal "${N2ST_PATH}" "/code/norlab-shell-script-tools"
+  assert_regex "${N2ST_VERSION}" [0-9]+\.[0-9]+\.[0-9]+
 }
 
 @test "${TESTED_FILE} › validate the import function mechanism › expect pass" {
@@ -117,6 +119,49 @@ teardown() {
 #  run n2st::set_which_architecture_and_os >&3
   run n2st::set_which_architecture_and_os
   assert_success
+}
+
+@test "${TESTED_FILE} › validate return to original dir on script exit › expect pass" {
+  # ....Test setup.................................................................................
+  local ORIGINAL_CWD=$(pwd)
+
+  # ....Import N2ST library........................................................................
+  source "$TESTED_FILE"
+
+  # ....Tests......................................................................................
+  assert_equal "$(pwd)" "${ORIGINAL_CWD}"
+}
+
+@test "${TESTED_FILE} › validate return to original dir on script exit (superproject version) › expect pass" {
+  TEST_N2ST_PATH="/code/norlab-shell-script-tools"
+  SUPERPROJECT_NAME="dockerized-norlab-project-mock"
+  SUPERPROJECT_PATH="/code/${SUPERPROJECT_NAME}"
+
+  # ....Setup superproject.........................................................................
+  assert_equal "$(pwd)" "$TEST_N2ST_PATH"
+  cd ..
+  assert_equal "$(pwd)" "/code"
+
+  git clone "https://github.com/norlab-ulaval/${SUPERPROJECT_NAME}.git"
+  assert_dir_exist "${SUPERPROJECT_PATH}"
+
+  # ....Test setup.................................................................................
+  cd "${SUPERPROJECT_PATH}"
+  local ORIGINAL_CWD=$(pwd)
+
+#  # Visualise the testing directories
+#  (echo && pwd && tree -L 2 -a) >&3
+
+  # ....Import N2ST library........................................................................
+#  cd "$TEST_N2ST_PATH"
+  source "${TEST_N2ST_PATH}/${TESTED_FILE}"
+
+  # ....Tests......................................................................................
+  assert_equal "$(pwd)" "${ORIGINAL_CWD}"
+
+  # ....Teardown this test case ...................................................................
+  # Delete cloned repository mock
+  rm -rf "$SUPERPROJECT_PATH"
 }
 
 


### PR DESCRIPTION
# Description

This pull-request comprises three changes aimed at improving the robustness of the `import_norlab_shell_script_tools_lib.bash`.

1. **Refactor: Replace pushd/popd with Local Variable Handling for Directory Navigation**
   We are opting for a local variable approach in handling directory navigation to bolster our script against nested error situations. In addition, there's the removal of redundant pushd and popd commands, simplifying our script while enhancing its maintainability. This addresses issues *NMO-414* and *NMO-581*.

2. **Fix: Improve Error Handling and Messages in Library Sourcing Script**
   To increase our error-handling efficiency, we've added detailed error messages to `pushd`, `cd`, and `source` commands, thus ensuring the script provides detailed feedback when failing to navigate directories or sourcing files. This change deals with the enhancements specified in issue *NMO-581*.

3. **Test: Add Tests for Return to Original Directory on Script Exit**
   There's the addition of new test cases to ensure the script returns to the original directory on exit. These tests verify functionality in both standalone and superproject contexts. Additionally, we've included a test for `N2ST_VERSION` (fetching and format).

# Checklist:

### Code related
- [x] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [x] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)


 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_
