### PR TITLE
Remove redundant --no-cache flag from Docker build

### DIFF
--- a/tests/bats_testing_tools/run_bats_tests_in_docker.bash
+++ b/tests/bats_testing_tools/run_bats_tests_in_docker.bash
@@ -98,7 +98,6 @@ docker build \
   --build-arg "N2ST_VERSION=${N2ST_VERSION:?err}" \
   --file "${N2ST_BATS_TESTING_TOOLS_ABS_PATH}/Dockerfile.bats-core-code-isolation.${BATS_DOCKERFILE_DISTRO}" \
   --tag "${CONTAINER_TAG}" \
-  --no-cache \
   "${REPO_ROOT}"
 
 


### PR DESCRIPTION
# Description

This pull request fixes a minor issue in the Docker build process by removing the unnecessary `--no-cache` flag in the build command. The fix ensures optimized usage of Docker's caching mechanism, improving build performance and avoiding unnecessary cache bypasses.




# Checklist:

### Code related
- [ ] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [ ] I have commented hard-to-understand code 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [ ] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)


 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_