### PR TITLE
Make Bats testing tools more efficient

### DIFF
--- a/.run/run bats tests  › 'test_import_lib.bats'.run.xml
+++ b/.run/run bats tests  › 'test_import_lib.bats'.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run bats tests  › 'test_import_lib.bats'" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tests/bats_testing_tools/run_bats_tests_in_docker.bash" />
+    <option name="SCRIPT_OPTIONS" value="tests/test_import_lib.bats" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs>
+      <env name="DOCKER_CONTEXT" value="desktop-linux" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/run bats tests  › 'test_prompt_utilities.bats'.run.xml
+++ b/.run/run bats tests  › 'test_prompt_utilities.bats'.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run bats tests  › 'test_prompt_utilities.bats'" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tests/bats_testing_tools/run_bats_tests_in_docker.bash" />
+    <option name="SCRIPT_OPTIONS" value="tests/test_prompt_utilities.bats" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs>
+      <env name="DOCKER_CONTEXT" value="desktop-linux" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/run bats tests  › 'tests' (all) (execute as a command).run.xml
+++ b/.run/run bats tests  › 'tests' (all) (execute as a command).run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run bats tests  › 'tests' (all) (execute as a command)" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="clear &amp;&amp; bash tests/bats_testing_tools/run_bats_tests_in_docker.bash tests" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tests/bats_testing_tools/run_bats_tests_in_docker.bash" />
+    <option name="SCRIPT_OPTIONS" value="tests" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs>
+      <env name="DOCKER_CONTEXT" value="desktop-linux" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/run bats tests  › 'tests' (all).run.xml
+++ b/.run/run bats tests  › 'tests' (all).run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run bats tests  › 'tests' (all)" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tests/bats_testing_tools/run_bats_tests_in_docker.bash" />
+    <option name="SCRIPT_OPTIONS" value="tests" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs>
+      <env name="DOCKER_CONTEXT" value="desktop-linux" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/run bats tests › 'test_docker_utilities.bats'.run.xml
+++ b/.run/run bats tests › 'test_docker_utilities.bats'.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run bats tests › 'test_docker_utilities.bats'" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tests/bats_testing_tools/run_bats_tests_in_docker.bash" />
+    <option name="SCRIPT_OPTIONS" value="tests/test_docker_utilities.bats" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs>
+      <env name="DOCKER_CONTEXT" value="desktop-linux" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/run bats tests › 'test_dotenv_files.bats'.run.xml
+++ b/.run/run bats tests › 'test_dotenv_files.bats'.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run bats tests › 'test_dotenv_files.bats'" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tests/bats_testing_tools/run_bats_tests_in_docker.bash" />
+    <option name="SCRIPT_OPTIONS" value="tests/test_dotenv_files.bats" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs>
+      <env name="DOCKER_CONTEXT" value="desktop-linux" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/run bats tests › 'test_general_utilities.bats'.run.xml
+++ b/.run/run bats tests › 'test_general_utilities.bats'.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run bats tests › 'test_general_utilities.bats'" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tests/bats_testing_tools/run_bats_tests_in_docker.bash" />
+    <option name="SCRIPT_OPTIONS" value="tests/test_general_utilities.bats" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs>
+      <env name="DOCKER_CONTEXT" value="desktop-linux" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/run bats tests › 'test_install_docker_tools.bats'.run.xml
+++ b/.run/run bats tests › 'test_install_docker_tools.bats'.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run bats tests › 'test_install_docker_tools.bats'" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tests/bats_testing_tools/run_bats_tests_in_docker.bash" />
+    <option name="SCRIPT_OPTIONS" value="tests/test_install_docker_tools.bats" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs>
+      <env name="DOCKER_CONTEXT" value="desktop-linux" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/run bats tests › 'test_teamcity_utilities.bats'.run.xml
+++ b/.run/run bats tests › 'test_teamcity_utilities.bats'.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run bats tests › 'test_teamcity_utilities.bats'" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tests/bats_testing_tools/run_bats_tests_in_docker.bash" />
+    <option name="SCRIPT_OPTIONS" value="tests/test_teamcity_utilities.bats" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs>
+      <env name="DOCKER_CONTEXT" value="desktop-linux" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/run bats tests › 'test_template.bats'.run.xml
+++ b/.run/run bats tests › 'test_template.bats'.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run bats tests › 'test_template.bats'" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tests/bats_testing_tools/run_bats_tests_in_docker.bash" />
+    <option name="SCRIPT_OPTIONS" value="tests/tests_template/test_template.bats" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs>
+      <env name="DOCKER_CONTEXT" value="desktop-linux" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/run bats tests › 'test_terminal_splash.bats'.run.xml
+++ b/.run/run bats tests › 'test_terminal_splash.bats'.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run bats tests › 'test_terminal_splash.bats'" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tests/bats_testing_tools/run_bats_tests_in_docker.bash" />
+    <option name="SCRIPT_OPTIONS" value="tests/test_terminal_splash.bats" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs>
+      <env name="DOCKER_CONTEXT" value="desktop-linux" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/run bats tests › 'test_which_architecture_and_os.bats'.run.xml
+++ b/.run/run bats tests › 'test_which_architecture_and_os.bats'.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run bats tests › 'test_which_architecture_and_os.bats'" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tests/bats_testing_tools/run_bats_tests_in_docker.bash" />
+    <option name="SCRIPT_OPTIONS" value="tests/test_which_architecture_and_os.bats" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs>
+      <env name="DOCKER_CONTEXT" value="desktop-linux" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/run bats tests › 'test_which_python_version.bats'.run.xml
+++ b/.run/run bats tests › 'test_which_python_version.bats'.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run bats tests › 'test_which_python_version.bats'" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tests/bats_testing_tools/run_bats_tests_in_docker.bash" />
+    <option name="SCRIPT_OPTIONS" value="tests/test_which_python_version.bats" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs>
+      <env name="DOCKER_CONTEXT" value="desktop-linux" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.alpine
+++ b/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.alpine
@@ -29,11 +29,11 @@ RUN apk --no-cache add \
     git \
     tree
 
-# ....Setup project source code....................................................................
-COPY ./bats_helper_functions.bash $SRC_CODE_PATH/bats_testing_tools/bats_helper_functions.bash
-#RUN chown -R $(whoami) $SRC_CODE_PATH
+# ....Setup test environment.......................................................................
+WORKDIR "${SRC_CODE_PATH}"
+RUN git config --global --add safe.directory "${SRC_CODE_PATH}"
+COPY ./bats_helper_functions.bash ./tests/bats_testing_tools/bats_helper_functions.bash
 
 # ====End==========================================================================================
 WORKDIR $SRC_CODE_PATH
-
 ENTRYPOINT [ "/tini", "--", "bash", "bats", "--recursive", "--verbose-run", "--print-output-on-failure" ]

--- a/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.alpine
+++ b/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.alpine
@@ -10,7 +10,6 @@ ENV N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH=${N2ST_BATS_TESTING_TOOLS_RELATIVE_PAT
 ARG TEAMCITY_VERSION
 ENV TEAMCITY_VERSION=${TEAMCITY_VERSION}
 
-# (Priority) ToDo: implement >> next bloc ↓↓ (ref task NMO-570)
 ARG N2ST_VERSION
 LABEL norlab.tools.norlab-shell-script-tools.tester="${N2ST_VERSION:?err}"
 LABEL org.opencontainers.image.authors="luc.coupal.1@ulaval.ca"
@@ -31,8 +30,7 @@ RUN apk --no-cache add \
     tree
 
 # ....Setup project source code....................................................................
-COPY . $SRC_CODE_PATH
-COPY "${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}/bats_helper_functions.bash" $SRC_CODE_PATH/bats_testing_tools/bats_helper_functions.bash
+COPY ./bats_helper_functions.bash $SRC_CODE_PATH/bats_testing_tools/bats_helper_functions.bash
 #RUN chown -R $(whoami) $SRC_CODE_PATH
 
 # ====End==========================================================================================

--- a/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.ubuntu
+++ b/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.ubuntu
@@ -16,14 +16,6 @@ ENV N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH=${N2ST_BATS_TESTING_TOOLS_RELATIVE_PAT
 ARG TEAMCITY_VERSION
 ENV TEAMCITY_VERSION=${TEAMCITY_VERSION}
 
-# (Priority) ToDo: on task end >> delete next bloc ↓↓
-#ARG SUPER_PROJECT_USER
-#ARG SUPER_PROJECT_UID
-#ARG SUPER_PROJECT_GID
-#ENV SUPER_PROJECT_USER=${SUPER_PROJECT_USER:?'Build argument needs to be set and non-empty.'}
-#ENV SUPER_PROJECT_UID=${SUPER_PROJECT_UID:?'Build argument needs to be set and non-empty.'}
-#ENV SUPER_PROJECT_GID=${SUPER_PROJECT_GID:?'Build argument needs to be set and non-empty.'}
-
 ARG N2ST_VERSION
 LABEL norlab.tools.norlab-shell-script-tools.tester="${N2ST_VERSION:?err}"
 LABEL org.opencontainers.image.authors="luc.coupal.1@ulaval.ca"
@@ -73,40 +65,11 @@ RUN apt-get update \
         tini \
     && rm -rf /var/lib/apt/lists/*
 
-# ....Setup N2ST utils.............................................................................
+# ....Setup test environment.......................................................................
 WORKDIR "${SRC_CODE_PATH}"
+RUN git config --global --add safe.directory "${SRC_CODE_PATH}"
 COPY ./bats_helper_functions.bash ./tests/bats_testing_tools/bats_helper_functions.bash
 
-# ....Setup super project user.....................................................................
-#RUN <<EOF
-#    #!/bin/bash
-#    # Inspired from https://roboticseabass.com/2023/07/09/updated-guide-docker-and-ros2/
-#    {
-#        groupadd --force --gid "${SUPER_PROJECT_GID}" "${SUPER_PROJECT_USER}"
-#        useradd --uid "${SUPER_PROJECT_UID}" --gid "${SUPER_PROJECT_GID}" --create-home "${SUPER_PROJECT_USER}"
-#        echo "${SUPER_PROJECT_USER} ALL=(root) NOPASSWD:ALL" >/etc/sudoers.d/"${SUPER_PROJECT_USER}"
-#        chmod 0440 "/etc/sudoers.d/${SUPER_PROJECT_USER}"
-#        mkdir -p "${SUPER_PROJECT_USER_HOME}"
-#        chown -R "${SUPER_PROJECT_UID}":"${SUPER_PROJECT_GID}" "${SUPER_PROJECT_USER_HOME}"
-#
-#        # Add the 'video' groups to new user as it's required for GPU access.
-#        # (not a problem on norlab-og but mandatory on Jetson device)
-#        # Ref: https://forums.developer.nvidia.com/t/how-to-properly-create-new-users/68660/2
-#        usermod -a -G video,sudo "${SUPER_PROJECT_USER}"
-#    }
-#
-#    {
-#      chown -R $(id -u ${SUPER_PROJECT_USER}):$(id -g ${SUPER_PROJECT_USER}) "${SRC_CODE_PATH}"
-#      chown -R $(id -u ${SUPER_PROJECT_USER}):$(id -g ${SUPER_PROJECT_USER}) "${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}"
-#    }
-#EOF
-#
-#
-## ====End==========================================================================================
-#USER ${SUPER_PROJECT_USER:?'Env variable needs to be set and non-empty.'}
-#SHELL ["/bin/bash", "-c"]
-
-## ====End==========================================================================================
-RUN git config --global --add safe.directory "${SRC_CODE_PATH}"
+## ====End=========================================================================================
 WORKDIR "${SRC_CODE_PATH}"
 ENTRYPOINT [ "/usr/bin/tini", "--", "bash", "bats", "--recursive", "--verbose-run", "--print-output-on-failure" ]

--- a/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.ubuntu
+++ b/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.ubuntu
@@ -60,19 +60,13 @@ RUN ln -s /opt/bats/bin/bats /usr/local/bin/bats
 COPY --from=bats-core-base-img /opt/bats/ /opt/bats/
 COPY --from=bats-core-base-img /usr/lib/bats/ /usr/lib/bats/
 
-#RUN git clone https://github.com/bats-core/bats-core.git \
-#    cd bats-core \
-#    ./install.sh /usr/local
-
 RUN apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
         tini \
     && rm -rf /var/lib/apt/lists/*
 
-# ....Setup project source code....................................................................
-COPY . $SRC_CODE_PATH
-COPY "${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}/bats_helper_functions.bash" $SRC_CODE_PATH/tests/bats_testing_tools/bats_helper_functions.bash
-#RUN chown -R $(whoami) $SRC_CODE_PATH
+# ....Setup N2ST utils.............................................................................
+COPY ./bats_helper_functions.bash $SRC_CODE_PATH/tests/bats_testing_tools/bats_helper_functions.bash
 
 # ====End==========================================================================================
 WORKDIR $SRC_CODE_PATH

--- a/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.ubuntu
+++ b/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.ubuntu
@@ -16,6 +16,14 @@ ENV N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH=${N2ST_BATS_TESTING_TOOLS_RELATIVE_PAT
 ARG TEAMCITY_VERSION
 ENV TEAMCITY_VERSION=${TEAMCITY_VERSION}
 
+# (Priority) ToDo: on task end >> delete next bloc ↓↓
+#ARG SUPER_PROJECT_USER
+#ARG SUPER_PROJECT_UID
+#ARG SUPER_PROJECT_GID
+#ENV SUPER_PROJECT_USER=${SUPER_PROJECT_USER:?'Build argument needs to be set and non-empty.'}
+#ENV SUPER_PROJECT_UID=${SUPER_PROJECT_UID:?'Build argument needs to be set and non-empty.'}
+#ENV SUPER_PROJECT_GID=${SUPER_PROJECT_GID:?'Build argument needs to be set and non-empty.'}
+
 ARG N2ST_VERSION
 LABEL norlab.tools.norlab-shell-script-tools.tester="${N2ST_VERSION:?err}"
 LABEL org.opencontainers.image.authors="luc.coupal.1@ulaval.ca"
@@ -66,9 +74,39 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # ....Setup N2ST utils.............................................................................
-COPY ./bats_helper_functions.bash $SRC_CODE_PATH/tests/bats_testing_tools/bats_helper_functions.bash
+WORKDIR "${SRC_CODE_PATH}"
+COPY ./bats_helper_functions.bash ./tests/bats_testing_tools/bats_helper_functions.bash
 
-# ====End==========================================================================================
-WORKDIR $SRC_CODE_PATH
+# ....Setup super project user.....................................................................
+#RUN <<EOF
+#    #!/bin/bash
+#    # Inspired from https://roboticseabass.com/2023/07/09/updated-guide-docker-and-ros2/
+#    {
+#        groupadd --force --gid "${SUPER_PROJECT_GID}" "${SUPER_PROJECT_USER}"
+#        useradd --uid "${SUPER_PROJECT_UID}" --gid "${SUPER_PROJECT_GID}" --create-home "${SUPER_PROJECT_USER}"
+#        echo "${SUPER_PROJECT_USER} ALL=(root) NOPASSWD:ALL" >/etc/sudoers.d/"${SUPER_PROJECT_USER}"
+#        chmod 0440 "/etc/sudoers.d/${SUPER_PROJECT_USER}"
+#        mkdir -p "${SUPER_PROJECT_USER_HOME}"
+#        chown -R "${SUPER_PROJECT_UID}":"${SUPER_PROJECT_GID}" "${SUPER_PROJECT_USER_HOME}"
+#
+#        # Add the 'video' groups to new user as it's required for GPU access.
+#        # (not a problem on norlab-og but mandatory on Jetson device)
+#        # Ref: https://forums.developer.nvidia.com/t/how-to-properly-create-new-users/68660/2
+#        usermod -a -G video,sudo "${SUPER_PROJECT_USER}"
+#    }
+#
+#    {
+#      chown -R $(id -u ${SUPER_PROJECT_USER}):$(id -g ${SUPER_PROJECT_USER}) "${SRC_CODE_PATH}"
+#      chown -R $(id -u ${SUPER_PROJECT_USER}):$(id -g ${SUPER_PROJECT_USER}) "${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}"
+#    }
+#EOF
+#
+#
+## ====End==========================================================================================
+#USER ${SUPER_PROJECT_USER:?'Env variable needs to be set and non-empty.'}
+#SHELL ["/bin/bash", "-c"]
 
+## ====End==========================================================================================
+RUN git config --global --add safe.directory "${SRC_CODE_PATH}"
+WORKDIR "${SRC_CODE_PATH}"
 ENTRYPOINT [ "/usr/bin/tini", "--", "bash", "bats", "--recursive", "--verbose-run", "--print-output-on-failure" ]

--- a/tests/bats_testing_tools/run_bats_tests_in_docker.bash
+++ b/tests/bats_testing_tools/run_bats_tests_in_docker.bash
@@ -98,7 +98,7 @@ docker build \
   --build-arg "N2ST_VERSION=${N2ST_VERSION:?err}" \
   --file "${N2ST_BATS_TESTING_TOOLS_ABS_PATH}/Dockerfile.bats-core-code-isolation.${BATS_DOCKERFILE_DISTRO}" \
   --tag "${CONTAINER_TAG}" \
-  "${REPO_ROOT}"
+  "${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}"
 
 
 if [[ ${TEAMCITY_VERSION} ]]; then
@@ -114,9 +114,18 @@ fi
 
 if [[ ${TEAMCITY_VERSION} ]]; then
   # The '--interactive' flag is not compatible with TeamCity build agent
-  docker run --tty --rm "${CONTAINER_TAG}" "$RUN_TESTS_IN_DIR"
+  docker run \
+      --tty \
+      --rm \
+      --volume "${SUPER_PROJECT_GIT_ROOT}":/code/"${PROJECT_GIT_NAME}":ro \
+      "${CONTAINER_TAG}" "$RUN_TESTS_IN_DIR"
 else
-  docker run --interactive --tty --rm "${CONTAINER_TAG}" "$RUN_TESTS_IN_DIR"
+  docker run \
+      --tty \
+      --rm \
+      --volume "${SUPER_PROJECT_GIT_ROOT}":/code/"${PROJECT_GIT_NAME}":ro \
+      --interactive \
+      "${CONTAINER_TAG}" "$RUN_TESTS_IN_DIR"
 fi
 DOCKER_EXIT_CODE=$?
 

--- a/tests/bats_testing_tools/run_bats_tests_in_docker.bash
+++ b/tests/bats_testing_tools/run_bats_tests_in_docker.bash
@@ -29,6 +29,11 @@ N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH=".${N2ST_BATS_TESTING_TOOLS_ABS_PATH/$REPO
 N2ST_PATH="${N2ST_BATS_TESTING_TOOLS_ABS_PATH}/../.."
 test -d "${N2ST_PATH}" || exit 1
 
+# ....Super project user related logic.............................................................
+SUPER_PROJECT_USER="$( id -un )"
+SUPER_PROJECT_UID="$( id -u )"
+SUPER_PROJECT_GID="$( id -g )"
+
 # ....Source project shell-scripts dependencies....................................................
 pushd "$(pwd)" >/dev/null || exit 1
 source "${N2ST_PATH}"/import_norlab_shell_script_tools_lib.bash || exit 1
@@ -99,6 +104,10 @@ docker build \
   --file "${N2ST_BATS_TESTING_TOOLS_ABS_PATH}/Dockerfile.bats-core-code-isolation.${BATS_DOCKERFILE_DISTRO}" \
   --tag "${CONTAINER_TAG}" \
   "${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}"
+#  --build-arg "SUPER_PROJECT_USER=${SUPER_PROJECT_USER:?err}" \
+#  --build-arg "SUPER_PROJECT_UID=${SUPER_PROJECT_UID:?err}" \
+#  --build-arg "SUPER_PROJECT_GID=${SUPER_PROJECT_GID:?err}" \
+#  --no-cache \
 
 
 if [[ ${TEAMCITY_VERSION} ]]; then
@@ -117,12 +126,14 @@ if [[ ${TEAMCITY_VERSION} ]]; then
   docker run \
       --tty \
       --rm \
+      --privileged \
       --volume "${SUPER_PROJECT_GIT_ROOT}":/code/"${PROJECT_GIT_NAME}":ro \
       "${CONTAINER_TAG}" "$RUN_TESTS_IN_DIR"
 else
   docker run \
       --tty \
       --rm \
+      --privileged \
       --volume "${SUPER_PROJECT_GIT_ROOT}":/code/"${PROJECT_GIT_NAME}":ro \
       --interactive \
       "${CONTAINER_TAG}" "$RUN_TESTS_IN_DIR"

--- a/tests/bats_testing_tools/run_bats_tests_in_docker.bash
+++ b/tests/bats_testing_tools/run_bats_tests_in_docker.bash
@@ -29,11 +29,6 @@ N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH=".${N2ST_BATS_TESTING_TOOLS_ABS_PATH/$REPO
 N2ST_PATH="${N2ST_BATS_TESTING_TOOLS_ABS_PATH}/../.."
 test -d "${N2ST_PATH}" || exit 1
 
-# ....Super project user related logic.............................................................
-SUPER_PROJECT_USER="$( id -un )"
-SUPER_PROJECT_UID="$( id -u )"
-SUPER_PROJECT_GID="$( id -g )"
-
 # ....Source project shell-scripts dependencies....................................................
 pushd "$(pwd)" >/dev/null || exit 1
 source "${N2ST_PATH}"/import_norlab_shell_script_tools_lib.bash || exit 1
@@ -104,11 +99,6 @@ docker build \
   --file "${N2ST_BATS_TESTING_TOOLS_ABS_PATH}/Dockerfile.bats-core-code-isolation.${BATS_DOCKERFILE_DISTRO}" \
   --tag "${CONTAINER_TAG}" \
   "${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}"
-#  --build-arg "SUPER_PROJECT_USER=${SUPER_PROJECT_USER:?err}" \
-#  --build-arg "SUPER_PROJECT_UID=${SUPER_PROJECT_UID:?err}" \
-#  --build-arg "SUPER_PROJECT_GID=${SUPER_PROJECT_GID:?err}" \
-#  --no-cache \
-
 
 if [[ ${TEAMCITY_VERSION} ]]; then
   echo -e "##teamcity[blockClosed name='${_MSG_BASE_TEAMCITY} Build custom bats-core docker image']"


### PR DESCRIPTION
# Description

This pull request enhances the efficiency of Bats testing tools by making several key updates to the `run_bats_tests_in_docker.bash` script. The changes include:
- Volume mounting to improve performance and reduce rebuild times.
- Making the Docker image lightweight by copying only necessary N2ST resources.
- Adjusting the build context to the N2ST testing tools directory instead of the super project root.
- Introducing multiple run configurations for executing various Bats tests in Docker.

Issue: N2ST-44

# Checklist:

### Code related
- [ ] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [ ] I have commented hard-to-understand code 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)


 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_