### PR TITLE
Update git safe.directory configuration in Dockerfile

### DIFF
--- a/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.alpine
+++ b/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.alpine
@@ -33,12 +33,19 @@ RUN apk --no-cache add \
 WORKDIR "${SRC_CODE_PATH}"
 
 # Note:
-#   About git `safe.directory` check "Giving a directory with `/*` appended to it will allow
-#   access to all repositories under the named directory."
-#   Ref  https://github.com/git/git/blob/313eec177ad010048b399d6fd14de871b517f7e3/Documentation/config/safe.txt#L47-L48
+#   About git `safe.directory` check
+#       "To completely opt-out of this security check, set `safe.directory` to the string `*`.
+#       This will allow all repositories to be treated as if their directory was listed in
+#       the `safe.directory` list."
+#       "Giving a directory with `/*` appended to it will allow access to all repositories under
+#       the named directory."
+#
+#   Ref
+#   - https://github.com/git/git/blob/313eec177ad010048b399d6fd14de871b517f7e3/Documentation/config/safe.txt#L42C1-L44C51
+#   - https://github.com/git/git/blob/313eec177ad010048b399d6fd14de871b517f7e3/Documentation/config/safe.txt#L47-L48
 #
 #   This is required in our case since SRC_CODE_PATH will often have git submodule
-RUN git config --global --add safe.directory "${SRC_CODE_PATH}/*"
+RUN git config --global --add safe.directory "*"
 
 COPY ./bats_helper_functions.bash ./tests/bats_testing_tools/bats_helper_functions.bash
 

--- a/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.alpine
+++ b/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.alpine
@@ -31,7 +31,15 @@ RUN apk --no-cache add \
 
 # ....Setup test environment.......................................................................
 WORKDIR "${SRC_CODE_PATH}"
-RUN git config --global --add safe.directory "${SRC_CODE_PATH}"
+
+# Note:
+#   About git `safe.directory` check "Giving a directory with `/*` appended to it will allow
+#   access to all repositories under the named directory."
+#   Ref  https://github.com/git/git/blob/313eec177ad010048b399d6fd14de871b517f7e3/Documentation/config/safe.txt#L47-L48
+#
+#   This is required in our case since SRC_CODE_PATH will often have git submodule
+RUN git config --global --add safe.directory "${SRC_CODE_PATH}/*"
+
 COPY ./bats_helper_functions.bash ./tests/bats_testing_tools/bats_helper_functions.bash
 
 # ====End==========================================================================================

--- a/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.ubuntu
+++ b/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.ubuntu
@@ -67,7 +67,15 @@ RUN apt-get update \
 
 # ....Setup test environment.......................................................................
 WORKDIR "${SRC_CODE_PATH}"
-RUN git config --global --add safe.directory "${SRC_CODE_PATH}"
+
+# Note:
+#   About git `safe.directory` check "Giving a directory with `/*` appended to it will allow
+#   access to all repositories under the named directory."
+#   Ref  https://github.com/git/git/blob/313eec177ad010048b399d6fd14de871b517f7e3/Documentation/config/safe.txt#L47-L48
+#
+#   This is required in our case since SRC_CODE_PATH will often have git submodule
+RUN git config --global --add safe.directory "${SRC_CODE_PATH}/*"
+
 COPY ./bats_helper_functions.bash ./tests/bats_testing_tools/bats_helper_functions.bash
 
 ## ====End=========================================================================================

--- a/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.ubuntu
+++ b/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.ubuntu
@@ -69,12 +69,19 @@ RUN apt-get update \
 WORKDIR "${SRC_CODE_PATH}"
 
 # Note:
-#   About git `safe.directory` check "Giving a directory with `/*` appended to it will allow
-#   access to all repositories under the named directory."
-#   Ref  https://github.com/git/git/blob/313eec177ad010048b399d6fd14de871b517f7e3/Documentation/config/safe.txt#L47-L48
+#   About git `safe.directory` check
+#       "To completely opt-out of this security check, set `safe.directory` to the string `*`.
+#       This will allow all repositories to be treated as if their directory was listed in
+#       the `safe.directory` list."
+#       "Giving a directory with `/*` appended to it will allow access to all repositories under
+#       the named directory."
+#
+#   Ref
+#   - https://github.com/git/git/blob/313eec177ad010048b399d6fd14de871b517f7e3/Documentation/config/safe.txt#L42C1-L44C51
+#   - https://github.com/git/git/blob/313eec177ad010048b399d6fd14de871b517f7e3/Documentation/config/safe.txt#L47-L48
 #
 #   This is required in our case since SRC_CODE_PATH will often have git submodule
-RUN git config --global --add safe.directory "${SRC_CODE_PATH}/*"
+RUN git config --global --add safe.directory "*"
 
 COPY ./bats_helper_functions.bash ./tests/bats_testing_tools/bats_helper_functions.bash
 


### PR DESCRIPTION
# Description

Updated the `git config` in the Dockerfile to set `safe.directory` as `${SRC_CODE_PATH}/*`, enabling access to all subdirectories. This resolves issues related to git submodules in the test environment. Added a reference to the git documentation for additional context.  
