### PR TITLE
Remove read-only flag from Docker volume mount in tests

### DIFF
--- a/tests/bats_testing_tools/run_bats_tests_in_docker.bash
+++ b/tests/bats_testing_tools/run_bats_tests_in_docker.bash
@@ -117,14 +117,14 @@ if [[ ${TEAMCITY_VERSION} ]]; then
       --tty \
       --rm \
       --privileged \
-      --volume "${SUPER_PROJECT_GIT_ROOT}":/code/"${PROJECT_GIT_NAME}":ro \
+      --volume "${SUPER_PROJECT_GIT_ROOT}":/code/"${PROJECT_GIT_NAME}" \
       "${CONTAINER_TAG}" "$RUN_TESTS_IN_DIR"
 else
   docker run \
       --tty \
       --rm \
       --privileged \
-      --volume "${SUPER_PROJECT_GIT_ROOT}":/code/"${PROJECT_GIT_NAME}":ro \
+      --volume "${SUPER_PROJECT_GIT_ROOT}":/code/"${PROJECT_GIT_NAME}" \
       --interactive \
       "${CONTAINER_TAG}" "$RUN_TESTS_IN_DIR"
 fi


### PR DESCRIPTION
# Description

This update removes the `ro` (read-only) flag from the Docker volume mount in the test environment.  
The change allows write access within the container, ensuring better compatibility and resolving potential write restrictions during test execution.  
