### PR TITLE
fix(splash): refine locale handling and improve centering function

### DIFF
--- a/src/function_library/terminal_splash.bash
+++ b/src/function_library/terminal_splash.bash
@@ -22,8 +22,8 @@
 #   none
 # Arguments:
 #   <theString>           The string to center
-#   <theStyle>            The style appended at the begining of the line (default to "\033[1;37m")
-#   <thePadCharacter>     The padding character to use (default to "\033[0m·")
+#   <theStyle>            The style appended at the begining of the line (set to ' ' to mute style)
+#   <thePadCharacter>     The padding character to use
 # Globals:
 #   read LC_CTYPE
 #   read LC_ALL
@@ -44,64 +44,95 @@ function n2st::echo_centering_str() {
   local the_str_pre=${1:?'Missing a mandatory parameter error'}
 #  local the_str=${1:?'Missing a mandatory parameter error'}
   local the_style="${2:?'Missing a mandatory parameter error'}"
-  local the_pad_cha="${3:?'Missing a mandatory parameter error'}"
+  local pad_char="${3:?'Missing a mandatory parameter error'}"
   local fill_left="${4:-""}"
   local fill_right="${5:-""}"
+  # ....Set env variables (post cli)...............................................................
+  # Add env var
+
 
   # ....Pre-check and set default locale...........................................................
-  # Add locale handling
-  local current_lc_ctype="${LC_CTYPE:-}"
+  # Save original locale settings
+  local original_lc_ctype="${LC_CTYPE:-}"
+  local original_lc_all="${LC_ALL:-}"
 
-  # Try using a default safe locale if the current one fails
-  local safe_locale="C.UTF-8"
-  if locale -a 2>/dev/null | grep -q "${safe_locale}"; then
-    export LC_CTYPE="${safe_locale}"
+  # Try to use a UTF-8 locale for consistent character handling
+  if locale -a 2>/dev/null | grep -q "C.UTF-8"; then
+      export LC_ALL="" LC_CTYPE="C.UTF-8"
   elif locale -a 2>/dev/null | grep -q "en_US.UTF-8"; then
-    export LC_CTYPE="en_US.UTF-8"
+      export LC_ALL="" LC_CTYPE="en_US.UTF-8"
   else
-    # Fallback to C locale which is guaranteed to exist
-    export LC_CTYPE="C"
+      export LC_ALL="" LC_CTYPE="C"
   fi
 
+  # Get terminal width more reliably
+  local term_width
+  local minimum_witdh=80
+  if [[ -n "$COLUMNS" ]]; then
+      term_width="$COLUMNS"
+  elif command -v tput >/dev/null 2>&1; then
+      if [[ -z "$TERM" || "$TERM" == "dumb" ]]; then
+          term_width=$(tput -T xterm-256color cols 2>/dev/null) || term_width="$minimum_witdh"
+      else
+          term_width=$(tput cols 2>/dev/null) || term_width="$minimum_witdh"
+      fi
+  else
+      term_width="$minimum_witdh"  # Default fallback
+  fi
+
+  local text_width
+#  printf -v the_str -- "%b" "${the_str_pre}" 2>/dev/null
+  the_str=$the_str_pre
+  text_width=${#the_str}
+  pad_char_len=${#pad_char}
+
+#  # Quick-hack for handling braille character (unicode) which sometime are diffculte to handle
+#  if [[ ${pad_char_len} -gt 1  ]]; then
+#    text_width=$(( text_width / 3))
+#  fi
+
+  # Calculate padding
+  local total_padding=$(( term_width - $((text_width / pad_char_len)) ))
+  local side_padding=$((total_padding / 2))
+
+  ## Note: debug lines
+  #echo -e "term_width: ${term_width}"
+  #echo -e "text_width: ${text_width}"
+  #echo -e "pad_char_len: ${pad_char_len}"
+  #echo -e "total_padding: ${total_padding}"
+  #echo -e "side_padding: ${side_padding}"
+
+  # Generate padding - using a more reliable method than seq
+  local pad=""
+  local i=0
+  while ((i < side_padding)); do
+      pad="${pad}${pad_char}"
+      ((i++))
+  done
 
   # ....Formating..................................................................................
+  if [[ "${the_style}" == " " ]]; then
+    the_style=""
+  fi
   if [[ ${TEAMCITY_VERSION} ]] || [[ ${IS_TEAMCITY_RUN} == true ]] ; then
-    local the_style_off="[0m"
+    the_style=""
+    local the_style_off=""
   else
     local the_style_off="\033[0m"
   fi
 
-  # ....Set terminal env var.......................................................................
-  # Ref https://bash.cyberciti.biz/guide/$TERM_variable
-  if [[ -z ${TERM} ]]; then
-    tput_flag=("-T" "xterm-256color")
-  elif [[ ${TERM} == dumb ]]; then
-    # "dumb" is the one set on TeamCity Agent
-    #unset tput_flag
-    tput_flag=("-T" "xterm-256color")
-  else
-    tput_flag=("-T" "$TERM")
-  fi
-
-
-  # ....Begin......................................................................................
-  printf -v the_str -- "%b" "${the_str_pre}" 2>/dev/null
-  local str_len=${#the_str}
-  local terminal_width
-  # shellcheck disable=SC2086
-  terminal_width="${COLUMNS:-$(tput "${tput_flag[@]}" cols)}"
-  local total_padding_len=$(( ${terminal_width} - ${str_len} ))
-  local single_side_padding_len=$(( ${total_padding_len} / 2 ))
-  local pad
-  pad=$(printf -- "$the_pad_cha%.0s" $(seq $single_side_padding_len))
-
   # Note: adding `2>/dev/null` at the end is a quick-hack. Will need a more robust solution.
   #       ref task N2ST-2 fix: splash LC_TYPE related error
-  LC_ALL='' LC_CTYPE=en_US.UTF-8 printf -- "%b%b%s%b%s%b%b\n" "${the_style}" "${fill_left}" "${pad}" "${the_str}" "${pad}" "${fill_right}" "${the_style_off}" 2>/dev/null
+  echo -n -e  "${the_style}"
+#  LC_CTYPE="${LC_CTYPE}" printf -- "%b%s%b%s%b\n" "${fill_left}" "${pad}" "${the_str}" "${pad}" "${fill_right}" 2>/dev/null
+  LC_CTYPE="${LC_CTYPE}" echo -e "${fill_left}${pad}${the_str}${pad}${fill_right}" 2>/dev/null
+  echo -n -e  "${the_style_off}"
 
   # ....Teardown...................................................................................
   # Restore original locale settings
-  export LC_CTYPE="${current_lc_ctype}"
+  export LC_CTYPE="${original_lc_ctype}"
+  export LC_ALL="${original_lc_all}"
+
   return 0
 }
 
@@ -146,21 +177,14 @@ function n2st::snow_splash() {
   local title=${1:-'NorLab'}
   local optional_url=${2:-'https://github.com/norlab-ulaval'}
 
-  local fill_t=''
-  local fill_u=''
-  if [[ ${IS_TEAMCITY_RUN} == true ]] || [[ ${TEAMCITY_VERSION} ]]; then
-    local fill_t='······'
-    local fill_u='      '
-  fi
-
   # Formatting
   #   - 1=Bold/bright
   #   - 2=Dim
   #   - 4=underline
   if [[ ${TEAMCITY_VERSION} ]] || [[ ${IS_TEAMCITY_RUN} == true ]] ; then
-    local title_formatting="[1m"
-    local snow_formatting="[2m"
-    local url_formatting="[2m"
+    local title_formatting=" "
+    local snow_formatting=" "
+    local url_formatting=" "
   else
     local title_formatting="\033[1m"
     local snow_formatting="\033[2m"
@@ -175,7 +199,7 @@ function n2st::snow_splash() {
   n2st::echo_centering_str "⢀⣤⡀⣿⣿⠀⠀⠉⣿⣿⡿⠁⠀⠀⣿⡟⣀⣤⠀⠀" "${snow_formatting}" "⠀"
   n2st::echo_centering_str "⠀⠙⣻⣿⣿⣧⠀⠀⢸⣿⠀⠀⢀⣿⣿⣿⣟⠉⠀⠀" "${snow_formatting}" "⠀"
   n2st::echo_centering_str "⠘⠛⠛⠉⠉⠙⠿⣿⣾⣿⣷⣿⠟⠉⠉⠙⠛⠛⠀⠀" "${snow_formatting}" "⠀"
-  n2st::echo_centering_str "···•· ${title} ··•••" "${title_formatting}" "·" "${fill_t}" "${fill_t}"
+  n2st::echo_centering_str "···•· ${title} ··•••" "${title_formatting}" "·"
   n2st::echo_centering_str "⢠⣶⣤⣄⣀⣤⣶⣿⢿⣿⢿⣿⣶⣄⣀⣤⣤⣶⠀⠀" "${snow_formatting}" "⠀"
   n2st::echo_centering_str "⠀⣨⣿⣿⣿⡟⠁⠀⢸⣿⠀⠀⠉⣿⣿⣿⣯⣀⠀⠀" "${snow_formatting}" "⠀"
   n2st::echo_centering_str "⠈⠛⠁⣿⣿⢀⠀⣠⣿⣿⣷⡀⠀⠈⣿⣧⠉⠛⢀⠀" "${snow_formatting}" "⠀"
@@ -183,8 +207,8 @@ function n2st::snow_splash() {
   n2st::echo_centering_str "⠀⠀⠀⠀⠀⠀⠀⠀⠘⠛⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀" "${snow_formatting}" "⠀"
   n2st::echo_centering_str "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀" "${snow_formatting}" "⠀"
   echo " "
-  n2st::echo_centering_str "https://norlab.ulaval.ca" "${url_formatting}" " " "${fill_u}" "${fill_u}"
-  n2st::echo_centering_str "${optional_url}" "${url_formatting}" " " "${fill_u}" "${fill_u}"
+  n2st::echo_centering_str "https://norlab.ulaval.ca" "${url_formatting}" " "
+  n2st::echo_centering_str "${optional_url}" "${url_formatting}" " "
   echo " "
   echo " "
 }
@@ -231,21 +255,15 @@ function n2st::norlab_splash() {
   local optional_url=${2:-'https://github.com/norlab-ulaval'}
   local splash_type=${3:-negative} # Option: small, negative or big
 
-  local fill_t=''
-  local fill_u=''
-  if [[ ${IS_TEAMCITY_RUN} == true ]] || [[ ${TEAMCITY_VERSION} ]]; then
-    local fill_t='······'
-    local fill_u='      '
-  fi
 
   # Formatting
   #   - 1=Bold/bright
   #   - 2=Dim
   #   - 4=underline
   if [[ ${TEAMCITY_VERSION} ]] || [[ ${IS_TEAMCITY_RUN} == true ]] ; then
-    local title_formatting="[1m"
-    local snow_formatting="[2m"
-    local url_formatting="[2m"
+    local title_formatting=" "
+    local snow_formatting=" "
+    local url_formatting=" "
   else
     local title_formatting="\033[1m"
     local snow_formatting="\033[2m"
@@ -266,7 +284,7 @@ function n2st::norlab_splash() {
     n2st::echo_centering_str "⠀⠀⠘⣿⣿⢡⡋⠙⠿⠀⣿⡀⢸⡟⠙⢷⣤⠀⣤⠞⠾⢿⡇⢰⡟⠀⠟⠉⢻⡟⣾⣿⠗⠀" "${snow_formatting}" "⠀"
     n2st::echo_centering_str "⠀⠀⠀⢰⢁⣿⣿⠛⠀⣀⠈⠀⢸⡇⢸⣶⣄⠀⣤⠘⡀⢸⠃⠈⠀⣀⠀⠛⣿⣼⠸⡄⠀⠀" "${snow_formatting}" "⠀"
     n2st::echo_centering_str "⠀⣶⣾⣿⣾⣿⣿⣿⠉⢀⣤⡶⠒⠀⠈⠛⢿⠀⠛⠚⠀⠀⠒⣶⣤⡀⢙⡿⣴⣿⣧⣿⣦⣤" "${snow_formatting}" "⠀"
-    n2st::echo_centering_str "···•· ${title} ··•••" "${title_formatting}" "·" "${fill_t}" "${fill_t}"
+    n2st::echo_centering_str "···•· ${title} ··•••" "${title_formatting}" "·"
     n2st::echo_centering_str "⠀⣿⣿⣏⣿⣿⣿⣿⡿⣿⣄⠀⠛⣿⡿⠛⠀⠀⠀⠒⣶⡮⠛⠢⠿⣛⣭⣿⣿⣿⣿⣿⣿⣿" "${snow_formatting}" "⠀"
     n2st::echo_centering_str "⠀⠈⠉⣿⢹⣿⣿⠛⢶⣤⡀⠉⠉⠀⢰⣿⣿⠀⣿⣷⡀⠀⠉⠉⣀⣤⡾⠛⣿⣿⡏⡿⠛⠉" "${snow_formatting}" "⠀"
     n2st::echo_centering_str "⠀⠀⠀⣨⣆⣿⣿⠟⠀⠀⣠⠀⢸⡇⠘⠉⣀⠀⡀⠉⠀⢸⡆⢰⡄⠀⠐⠿⣿⣿⣼⠀⠀⠀" "${snow_formatting}" "⠀"
@@ -277,8 +295,8 @@ function n2st::norlab_splash() {
     n2st::echo_centering_str "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠀⠀⠀⠀⣿⣿⣿⣿⠃⠀⠀⠀⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀" "${snow_formatting}" "⠀"
     n2st::echo_centering_str "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀" "${snow_formatting}" "⠀"
     echo " "
-    n2st::echo_centering_str "https://norlab.ulaval.ca" "${url_formatting}" " " "${fill_u}" "${fill_u}"
-    n2st::echo_centering_str "${optional_url}" "${url_formatting}" " " "${fill_u}" "${fill_u}"
+    n2st::echo_centering_str "https://norlab.ulaval.ca" "${url_formatting}" " "
+    n2st::echo_centering_str "${optional_url}" "${url_formatting}" " "
     echo " "
     echo " "
 
@@ -299,7 +317,7 @@ function n2st::norlab_splash() {
     n2st::echo_centering_str "⠀⠀⠀⠀⡿⢀⣿⣿⣟⠛⠉⠀⣀⣀⡀⠀⠀⠸⣿⠀⢸⣿⣶⣤⠀⠀⣤⣶⢸⡇⠀⣿⠇⠀⠀⢀⣀⣀⠀⠉⠛⣿⢃⣿⡄⢿⠀⠀⠀⠀" "${snow_formatting}" "⠀"
     n2st::echo_centering_str "⢀⣀⣤⣼⡇⣸⣿⣿⣿⣦⣶⠿⠛⠉⠀⢀⣠⡀⠀⠀⠘⢿⣿⣿⠀⠀⣿⠏⡸⠃⠀⠀⢀⣄⡀⠀⠉⠛⠿⣶⣴⠇⣼⣿⣇⢸⣇⡀⠀⠀" "${snow_formatting}" "⠀"
     n2st::echo_centering_str "⣿⣿⣿⣿⠁⣿⣿⣿⣿⣿⣿⣄⣠⣴⡾⠟⠉⠀⢀⣤⣄⠀⠈⠙⠀⠀⠁⠀⠀⣠⣤⡀⠀⠉⠻⢷⣦⣄⣠⡿⢃⣾⣿⣿⣿⠀⣿⣿⣿⣶" "${snow_formatting}" "⠀"
-    n2st::echo_centering_str "···•· ${title} ··•••" "${title_formatting}" "·" "${fill_t}" "${fill_t}"
+    n2st::echo_centering_str "···•· ${title} ··•••" "${title_formatting}" "·"
     n2st::echo_centering_str "⣿⣿⣿⣿⠀⣿⣿⣿⣿⣿⣿⣿⣿⣏⡀⠀⠐⠾⣿⣿⣿⡿⠒⠀⠀⠀⠀⠠⢴⣶⣦⣍⠳⠦⣄⣼⡿⠟⣋⣴⣿⣿⣿⣿⣿⠀⣿⣿⣿⣿" "${snow_formatting}" "⠀"
     n2st::echo_centering_str "⠿⣿⣿⣿⠀⣿⣿⣿⣿⣿⣿⠁⠉⠛⠿⣶⣤⡀⠀⠉⠁⠀⣠⣴⠀⠀⣦⣀⠀⠈⠉⠀⢀⣤⣶⠶⠒⠉⠈⣿⣿⣿⣿⣿⣿⢀⣿⣿⣿⣿" "${snow_formatting}" "⠀"
     n2st::echo_centering_str "⠀⠀⠈⢹⡇⢹⣿⣿⣿⠛⠛⠿⣶⣤⡀⠀⠉⠀⢀⠀⢰⣿⣿⣿⠀⠀⣿⣿⣿⠀⠀⡀⠀⠉⠀⢀⣤⣶⠿⠛⠻⣿⣿⣿⡏⢸⡟⠛⠉⠁" "${snow_formatting}" "⠀"
@@ -315,14 +333,14 @@ function n2st::norlab_splash() {
     n2st::echo_centering_str "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠸⣿⣿⣿⣿⣿⡟⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀" "${snow_formatting}" "⠀"
     n2st::echo_centering_str "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀" "${snow_formatting}" "⠀"
     echo " "
-    n2st::echo_centering_str "https://norlab.ulaval.ca" "${url_formatting}" " " "${fill_u}" "${fill_u}"
-    n2st::echo_centering_str "${optional_url}" "${url_formatting}" " " "${fill_u}" "${fill_u}"
+    n2st::echo_centering_str "https://norlab.ulaval.ca" "${url_formatting}" " "
+    n2st::echo_centering_str "${optional_url}" "${url_formatting}" " "
     echo " "
     echo " "
 
   elif [[ ${splash_type} == negative ]]; then
 
-    local SS="·"
+    local SS="⠐"
     if [[ ${TEAMCITY_VERSION} ]] || [[ ${IS_TEAMCITY_RUN} == true ]] ; then
       SS=""
     fi
@@ -339,7 +357,7 @@ function n2st::norlab_splash() {
     n2st::echo_centering_str "⣿⣿⣿⣿⣿⣿⣿⡿⢠⠃⠀⠀⠉⣻⣿⣿⣤⣿⣿⠀⣿⠛⠿⣿⣿⣿⣿⣿⢸⣿⠀⣿⣟⣤⣿⣿⣟⠉⠀⢠⠻⡀⣴⣿⣿⣿⣿⣿⣿⣿" "${snow_formatting}" "⣿"
     n2st::echo_centering_str "⣿⣿⣿⣿⣿⣿⡿⠀⡟⠀⠀⠈⠟⠋⠁⣤⣿⣿⣿⣶⣿⠂⠀⠀⣿⣿⠀⣿⢸⣿⣶⣿⣿⣿⣄⠈⠙⠁⢀⠋⠀⣿⠈⣿⣿⣿⣿⣿⣿⣿" "${snow_formatting}" "⣿"
     n2st::echo_centering_str "⣿⣿⣿⣿⠀⠀⠀⢰⠁⠀⠀⠀⠀⠹⠟⠉⣀⣴⣾⡿⠛⠿⣿⣦⣿⣿⣿⣿⠟⠛⢿⣷⣤⡀⠉⠋⠀⣠⠋⠀⠀⢸⠀⠀⠀⠉⣿⣿⣿⣿" "${snow_formatting}" "⣿"
-    n2st::echo_centering_str "${SS}··•· ${title} ··•••" "${title_formatting}" "·" "${fill_t}" "${fill_t}"
+    n2st::echo_centering_str "${SS}··•· ${title} ··•••" "${title_formatting}" "·"
     n2st::echo_centering_str "⣿⣿⣿⣿⠀⠀⠀⢸⠀⠀⠀⠀⠀⢀⡀⠈⠻⣿⣶⣄⠀⣀⣶⣿⣿⣿⣿⣦⣀⠀⣹⣦⣭⣥⣤⢖⠋⠀⠀⠀⠀⢸⠀⠀⠀⢸⣿⣿⣿⣿" "${snow_formatting}" "⣿"
     n2st::echo_centering_str "⣿⣿⣿⣿⣷⣶⣤⠀⡇⠀⠀⠀⡀⠉⠛⣿⣷⣦⣴⣿⣿⠛⠁⠀⣿⣿⠀⠉⢻⣿⣿⣤⣴⣾⡿⠛⠉⣀⠀⠀⠀⢸⠀⢀⣠⣼⣿⣿⣿⣿" "${snow_formatting}" "⣿"
     n2st::echo_centering_str "⣿⣿⣿⣿⣿⣿⣿⡆⢻⠀⠀⠈⠛⢿⣿⣾⣿⣿⣿⠀⣿⠀⣀⣴⣿⣿⣦⡀⢸⣿⠀⣿⡿⣿⣶⣿⠿⠛⠀⠀⠀⡟⣸⣿⣿⣿⣿⣿⣿⣿" "${snow_formatting}" "⣿"
@@ -352,8 +370,8 @@ function n2st::norlab_splash() {
     n2st::echo_centering_str "⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣄⣀⣀⣀⣀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿" "${snow_formatting}" "⣿"
     n2st::echo_centering_str "⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿" "${snow_formatting}" "⣿"
     echo " "
-    n2st::echo_centering_str "https://norlab.ulaval.ca" "${url_formatting}" " " "${fill_u}" "${fill_u}"
-    n2st::echo_centering_str "${optional_url}" "${url_formatting}" " " "${fill_u}" "${fill_u}"
+    n2st::echo_centering_str "https://norlab.ulaval.ca" "${url_formatting}" " "
+    n2st::echo_centering_str "${optional_url}" "${url_formatting}" " "
     echo " "
     echo " "
 

--- a/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.ubuntu
+++ b/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.ubuntu
@@ -28,7 +28,7 @@ SHELL ["/bin/bash", "-e", "-c"]
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV TERM=${TERM:-"xterm-256color"}
-ENV COLUMNS=80
+#ENV COLUMNS=80
 
 # ====Begin========================================================================================
 # ....Setup timezone and localization..............................................................

--- a/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.ubuntu
+++ b/tests/bats_testing_tools/Dockerfile.bats-core-code-isolation.ubuntu
@@ -27,8 +27,8 @@ LABEL org.opencontainers.image.authors="luc.coupal.1@ulaval.ca"
 SHELL ["/bin/bash", "-e", "-c"]
 ARG DEBIAN_FRONTEND=noninteractive
 
+ARG TERM
 ENV TERM=${TERM:-"xterm-256color"}
-#ENV COLUMNS=80
 
 # ====Begin========================================================================================
 # ....Setup timezone and localization..............................................................

--- a/tests/bats_testing_tools/run_bats_tests_in_docker.bash
+++ b/tests/bats_testing_tools/run_bats_tests_in_docker.bash
@@ -151,6 +151,7 @@ BUILD_FLAG+=(--build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1)
 BUILD_FLAG+=(--build-arg N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH="$N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH")
 BUILD_FLAG+=(--build-arg "TEAMCITY_VERSION=${TEAMCITY_VERSION}")
 BUILD_FLAG+=(--build-arg "N2ST_VERSION=${N2ST_VERSION:?err}")
+BUILD_FLAG+=(--build-arg "TERM=${TERM:-xterm-256color}")
 BUILD_FLAG+=(--file "${N2ST_BATS_TESTING_TOOLS_ABS_PATH}/Dockerfile.bats-core-code-isolation.${BATS_DOCKERFILE_DISTRO}")
 if [[ ${MOUNT_SRC_CODE_AS_A_VOLUME} == true ]]; then
   BUILD_FLAG+=(--target mount-version)

--- a/tests/test_terminal_splash.bats
+++ b/tests/test_terminal_splash.bats
@@ -127,8 +127,12 @@ teardown() {
 
   run n2st::echo_centering_str "$CENTERED_STR" "$THE_STYLE" "$THE_PAD_CHAR"
   assert_success
-  assert_output --partial "...[0m"
+  assert_output --regexp "^..."
+  assert_output --regexp "...$"
+  refute_output --partial "...\033[0m"
+  refute_output --partial "${THE_STYLE}..."
 }
+
 
 # ----n2st::snow_splash----------------------------------------------------------------------------
 @test "n2st::snow_splash › default" {
@@ -151,11 +155,15 @@ teardown() {
 
 @test "n2st::snow_splash › teamcity case" {
   IS_TEAMCITY_RUN=true
-
+#  printenv | grep -i -e 'TERM' -e 'TPUT'  -e 'COLUMNS' >&3
   run n2st::snow_splash
-  assert_line --index 2 --regexp "\["2m.*"\["0m
-  assert_output --regexp "\["1m.*"NorLab".*"\["0m
-  assert_output --regexp "\["2m.*"https://norlab.ulaval.ca".*"\["0m
+#  assert_line --index 2 --regexp "\["2m.*"\["0m
+  assert_output --regexp .*"NorLab".*
+  assert_output --regexp .*"https://norlab.ulaval.ca".*
+  assert_output --regexp "^..."
+  assert_output --regexp "...$"
+  refute_output --partial "...\033[0m"
+  refute_output --partial "${THE_STYLE}..."
 }
 
 # ----n2st::norlab_splash--------------------------------------------------------------------------------
@@ -203,9 +211,9 @@ teardown() {
   IS_TEAMCITY_RUN=true
 
   run n2st::norlab_splash
-  assert_line --index 2 --regexp "\["2m.*"\["0m
-  assert_output --regexp "\["1m.*"NorLab".*"\["0m
-  assert_output --regexp "\["2m.*"https://norlab.ulaval.ca".*"\["0m
+  refute_line --index 2 --regexp "\["2m.*"\["0m
+  refute_output --regexp "\["1m.*"NorLab".*"\["0m
+  refute_output --regexp "\["2m.*"https://norlab.ulaval.ca".*"\["0m
 }
 
 # ====legacy API support testing===================================================================

--- a/tests/test_terminal_splash.bats
+++ b/tests/test_terminal_splash.bats
@@ -118,7 +118,7 @@ teardown() {
   local THE_STYLE="\033[1m"
   local THE_PAD_CHAR="."
 
-  IS_TEAMCITY_RUN=true
+  export IS_TEAMCITY_RUN=true
 
 #  # (Priority) ToDo: debug › on task end >> mute next bloc ↓↓
 #  printenv | grep -i -e 'TERM' -e 'TPUT'  -e 'COLUMNS' >&3
@@ -131,6 +131,7 @@ teardown() {
   assert_output --regexp "...$"
   refute_output --partial "...\033[0m"
   refute_output --partial "${THE_STYLE}..."
+  unset IS_TEAMCITY_RUN
 }
 
 
@@ -154,7 +155,7 @@ teardown() {
 }
 
 @test "n2st::snow_splash › teamcity case" {
-  IS_TEAMCITY_RUN=true
+  export IS_TEAMCITY_RUN=true
 #  printenv | grep -i -e 'TERM' -e 'TPUT'  -e 'COLUMNS' >&3
   run n2st::snow_splash
 #  assert_line --index 2 --regexp "\["2m.*"\["0m
@@ -164,6 +165,7 @@ teardown() {
   assert_output --regexp "...$"
   refute_output --partial "...\033[0m"
   refute_output --partial "${THE_STYLE}..."
+  unset IS_TEAMCITY_RUN
 }
 
 # ----n2st::norlab_splash--------------------------------------------------------------------------------
@@ -208,12 +210,13 @@ teardown() {
 }
 
 @test "n2st::norlab_splash › teamcity case" {
-  IS_TEAMCITY_RUN=true
+  export IS_TEAMCITY_RUN=true
 
   run n2st::norlab_splash
   refute_line --index 2 --regexp "\["2m.*"\["0m
   refute_output --regexp "\["1m.*"NorLab".*"\["0m
   refute_output --regexp "\["2m.*"https://norlab.ulaval.ca".*"\["0m
+  unset IS_TEAMCITY_RUN
 }
 
 # ====legacy API support testing===================================================================


### PR DESCRIPTION
# Description

- Enhanced locale management in `n2st::echo_centering_str` to ensure consistent character handling, including fallback mechanisms.
- Replaced unreliable padding calculations with improved terminal width detection and new padding logic.
- Removed unnecessary style placeholders for better clarity and maintainability.
- Replaced manual terminal width fallback with `BATS_TEST_FILENAME` offset adjustment to enhance accuracy under test conditions.
- Simplified error handling in `n2st::echo_centering_str` to ensure seamless execution without warnings or errors.
- Standardized style variables and improved debug utilities for better readability and maintainability.

Issue N2ST-49, N2ST-2

# Checklist:

### Code related
- [x] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [x] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)


 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_
