### PR TITLE
Fix macOS Docker builder error for arm64 architecture

### DIFF
--- a/tests/bats_testing_tools/run_bats_tests_in_docker.bash
+++ b/tests/bats_testing_tools/run_bats_tests_in_docker.bash
@@ -121,7 +121,9 @@ if [[ -z ${BUILDX_BUILDER} ]]; then
   n2st::set_which_architecture_and_os
   n2st::print_msg "Current image architecture and os: $IMAGE_ARCH_AND_OS"
   if [[ $IMAGE_ARCH_AND_OS == 'darwin/arm64' ]]; then
-    export BUILDX_BUILDER=desktop-linux
+    # Note: Do nothing since the new macOs docker context/builder behavior produce error when
+    # setting BUILDX_BUILDER to desktop-linux/default. See issue NMO-742 for details.
+    :
   else
     export BUILDX_BUILDER=default
   fi


### PR DESCRIPTION
# Description

This pull request updates the build script to address a known error with Docker context/builder behavior on macOS arm64 architecture. The change skips setting the `BUILDX_BUILDER` environment variable for macOS arm64, preventing the issue. A reference comment has been added to explain the context of the modification.
