### PR TITLE
Enhance TeamCity message utilities and Docker command handling

### DIFF
--- a/src/function_library/teamcity_utilities.bash
+++ b/src/function_library/teamcity_utilities.bash
@@ -48,6 +48,21 @@ function n2st::set_is_teamcity_run_environment_variable() {
   export IS_TEAMCITY_RUN
 }
 
+# =================================================================================================
+# Escape string for TeamCity Service Message compliance
+# Ref: https://www.jetbrains.com/help/teamcity/service-messages.html#Escaped+Values
+#
+# Usage:
+#   echo -e "##teamcity[blockOpened name='${MSG_BASE_TEAMCITY} $(n2st::teamcity_service_msg_str_formater "${THE_MSG}")']"
+#
+# Note:
+# - Uses only standard POSIX features that work on both Ubuntu and macOS
+# =================================================================================================
+function n2st::teamcity_service_msg_str_formater() {
+  local input="$1"
+  printf '%s' "$input" | sed -e 's/|/||/g' -e 's/\[/|[/g' -e 's/\]/|]/g' -e "s/'/|'/g"
+}
+
 
 # =================================================================================================
 # Send TeamCity blockOpened/blockClosed service message
@@ -78,11 +93,12 @@ function n2st::teamcity_service_msg_blockOpened() {
   if [[ ${CURRENT_BLOCK_SERVICE_MSG} ]]; then
     n2st::print_msg_error_and_exit "The TeamCity bloc service message ${MSG_DIMMED_FORMAT}${CURRENT_BLOCK_SERVICE_MSG}${MSG_END_FORMAT} was not closed using function ${MSG_DIMMED_FORMAT}n2st::teamcity_service_msg_blockClosed${MSG_END_FORMAT}."
   else
-    export CURRENT_BLOCK_SERVICE_MSG="${THE_MSG}"
+    export CURRENT_BLOCK_SERVICE_MSG
+    CURRENT_BLOCK_SERVICE_MSG="$(n2st::teamcity_service_msg_str_formater "${THE_MSG}")"
   fi
 
   if [[ ${IS_TEAMCITY_RUN} == true ]]; then
-    echo -e "##teamcity[blockOpened name='${MSG_BASE_TEAMCITY} ${THE_MSG}']"
+    echo -e "##teamcity[blockOpened name='${MSG_BASE_TEAMCITY} $(n2st::teamcity_service_msg_str_formater "${THE_MSG}")']"
   else
     echo && n2st::print_msg "${THE_MSG}" && echo
   fi
@@ -95,6 +111,41 @@ function n2st::teamcity_service_msg_blockClosed() {
   # Reset the variable since the bloc is closed
   unset CURRENT_BLOCK_SERVICE_MSG
 }
+
+# =================================================================================================
+# Send TeamCity blockOpened/blockClosed service message (explicit blockClosed msg version)
+#   or print the message to console when executed outside a TeamCity Agent run.
+#
+# Usage:
+#   $ n2st::teamcity_service_msg_blockOpened_v2 "<theMessage>"
+#   $ ... many steps ...
+#   $ n2st::teamcity_service_msg_blockClosed_v2 "<theMessage>"
+#
+# Globals:
+#   Read        'IS_TEAMCITY_RUN'
+#   Read|write  'CURRENT_BLOCK_SERVICE_MSG'
+# Outputs:
+#   Output either
+#     - a TeamCity blockOpened/blockClosed service message
+#     - or print to console
+#
+# Reference:
+#   - TeamCity doc: https://www.jetbrains.com/help/teamcity/service-messages.html#Blocks+of+Service+Messages
+# =================================================================================================
+function n2st::teamcity_service_msg_blockOpened_v2() {
+  local THE_MSG=$1
+  if [[ ${IS_TEAMCITY_RUN} == true ]]; then
+    echo -e "##teamcity[blockOpened name='${MSG_BASE_TEAMCITY} $(n2st::teamcity_service_msg_str_formater "${THE_MSG}")']"
+  fi
+}
+
+function n2st::teamcity_service_msg_blockClosed_custom_v2() {
+  local THE_MSG=$1
+  if [[ ${IS_TEAMCITY_RUN} == true ]]; then
+    echo -e "##teamcity[blockClosed name='${MSG_BASE_TEAMCITY} $(n2st::teamcity_service_msg_str_formater "${THE_MSG}")']"
+  fi
+}
+
 
 # =================================================================================================
 # Send TeamCity compilationStarted/compilationFinished service message


### PR DESCRIPTION
# Description

This pull request introduces enhancements to the TeamCity service message utilities and Docker command handling:
- Added a function, `teamcity_service_msg_str_formater`, to escape strings for TeamCity compliance.
- Introduced `blockOpened_v2` and `blockClosed_custom_v2` for more explicit block messaging in TeamCity.
- Updated `show_and_execute_docker` with options to mock Docker commands and handle build failures more flexibly.
- Improved message handling for nested Docker virtualization scenarios, enhancing clarity and performance.

Related issues: NMO-582, NM0-756.

# Checklist:

### Code related
- [x] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [x] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)


 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_