### PR TITLE
Improve utility functions with enhanced handling, tests, and documentation

### DIFF
--- a/src/function_library/general_utilities.bash
+++ b/src/function_library/general_utilities.bash
@@ -75,7 +75,6 @@ function n2st::seek_and_modify_string_in_file() {
 # Globals:
 #   write 'PYTHON3_VERSION'
 # =================================================================================================
-# (NICE TO HAVE) ToDo: extend unit-test
 function n2st::set_which_python3_version() {
     PYTHON3_VERSION=$(python3 -c 'import sys; version=sys.version_info; print(f"{version.major}.{version.minor}")') || return 1
     export PYTHON3_VERSION
@@ -106,7 +105,6 @@ function n2st::set_which_python3_version() {
 # Returns:
 #   exit 1 in case of unsupported processor architecture
 # =================================================================================================
-# (NICE TO HAVE) ToDo: extend unit-test
 # (NICE TO HAVE) ToDo: assessment >> check the convention used by docker >> os[/arch[/variant]]
 #       linux/arm64/v8
 #       darwin/arm64/v8
@@ -114,19 +112,21 @@ function n2st::set_which_python3_version() {
 #     ref: https://docs.docker.com/compose/compose-file/05-services/#platform
 function n2st::set_which_architecture_and_os() {
   if [[ $(uname -m) == "aarch64" ]]; then
-    if [[ -n $(uname -r | grep tegra) ]]; then
+    if uname -r | grep -q "tegra" 2>/dev/null; then
       export IMAGE_ARCH_AND_OS='l4t/arm64'
     elif [[ $(uname) == "Linux" ]]; then
         export IMAGE_ARCH_AND_OS='linux/arm64'
     else
-      echo -e "${MSG_ERROR} Unsupported OS for aarch64 processor" 1>&2
+      n2st::print_msg_error "Unsupported OS for aarch64 processor"
+      return 1
     fi
   elif [[ $(uname -m) == "arm64" ]] && [[ $(uname) == "Darwin" ]]; then
     export IMAGE_ARCH_AND_OS='darwin/arm64'
   elif [[ $(uname -m) == "x86_64" ]] && [[ $(uname) == "Linux" ]]; then
     export IMAGE_ARCH_AND_OS='linux/x86'
   else
-    n2st::print_msg_error "Unsupported processor architecture" || return 1
+    n2st::print_msg_error "Unsupported processor architecture"
+    return 1
   fi
   echo "${IMAGE_ARCH_AND_OS}"
   return 0

--- a/src/function_library/general_utilities.bash
+++ b/src/function_library/general_utilities.bash
@@ -68,7 +68,8 @@ function n2st::seek_and_modify_string_in_file() {
 # Usage:
 #   $ n2st::set_which_python3_version
 #   3.12
-#   $ echo "${PYTHON3_VERSION}"
+#   do something else...
+#   $ echo $PYTHON3_VERSION
 #   3.12
 #
 # Globals:
@@ -95,7 +96,8 @@ function n2st::set_which_python3_version() {
 # Usage:
 #   $ n2st::set_which_architecture_and_os
 #   linux\arm64
-#   $ echo "${IMAGE_ARCH_AND_OS}"
+#   do something else...
+#   $ echo "$IMAGE_ARCH_AND_OS"
 #   linux\arm64
 #
 # Globals:

--- a/src/function_library/general_utilities.bash
+++ b/src/function_library/general_utilities.bash
@@ -63,35 +63,43 @@ function n2st::seek_and_modify_string_in_file() {
 }
 
 # =================================================================================================
-# Check the current python version and set PYTHON3_VERSION environment variable
+# Print to stdout the current python version (major.minor) and set PYTHON3_VERSION env variable.
 #
 # Usage:
 #   $ n2st::set_which_python3_version
+#   3.12
+#   $ echo "${PYTHON3_VERSION}"
+#   3.12
 #
 # Globals:
 #   write 'PYTHON3_VERSION'
 # =================================================================================================
 # (NICE TO HAVE) ToDo: extend unit-test
 function n2st::set_which_python3_version() {
-    PYTHON3_VERSION=$(python3 -c 'import sys; version=sys.version_info; print(f"{version.major}.{version.minor}")')
+    PYTHON3_VERSION=$(python3 -c 'import sys; version=sys.version_info; print(f"{version.major}.{version.minor}")') || return 1
     export PYTHON3_VERSION
+    echo "${PYTHON3_VERSION}"
+    return 0
 }
 
 # =================================================================================================
-# Check the host architecture plus OS type and set IMAGE_ARCH_AND_OS environment variable as either
-#       - IMAGE_ARCH_AND_OS=darwin\arm64
-#       - IMAGE_ARCH_AND_OS=linux\x86
-#       - IMAGE_ARCH_AND_OS=linux\arm64
-#       - IMAGE_ARCH_AND_OS=l4t\arm64
+# Check the host architecture plus OS type and set IMAGE_ARCH_AND_OS environment variable to:
+#  - darwin\arm64
+#  - linux\x86
+#  - linux\arm64
+#  - l4t\arm64
 # depending on which architecture and OS type the script is running:
-#     - ARCH: aarch64, arm64, x86_64
-#     - OS: Linux, Darwin, Window
+#  - Host OS being one of 'Linux', 'L4T' or 'Darwin'
+#  - Host ARCH being one of 'aarch64', 'arm64' or 'x86_64'
 #
 # Usage:
 #   $ n2st::set_which_architecture_and_os
+#   linux\arm64
+#   $ echo "${IMAGE_ARCH_AND_OS}"
+#   linux\arm64
 #
 # Globals:
-#   write IMAGE_ARCH_AND_OS
+#   write 'IMAGE_ARCH_AND_OS'
 #
 # Returns:
 #   exit 1 in case of unsupported processor architecture
@@ -116,8 +124,10 @@ function n2st::set_which_architecture_and_os() {
   elif [[ $(uname -m) == "x86_64" ]] && [[ $(uname) == "Linux" ]]; then
     export IMAGE_ARCH_AND_OS='linux/x86'
   else
-    n2st::print_msg_error_and_exit "Unsupported processor architecture"
+    n2st::print_msg_error "Unsupported processor architecture" || return 1
   fi
+  echo "${IMAGE_ARCH_AND_OS}"
+  return 0
 }
 
 # ====legacy API support===========================================================================

--- a/tests/test_general_utilities.bats
+++ b/tests/test_general_utilities.bats
@@ -103,21 +103,165 @@ teardown() {
   assert_output --partial "${MODIFIED_STR}"
 }
 
+
+# ....n2st::set_which_python3_version ok...........................................................
 @test "n2st::set_which_python3_version ok" {
+  function python3() {
+    # Mock python3 command for outputing python3 version
+    echo "3.10"
+  }
+  export -f python3
+
   run n2st::set_which_python3_version
   assert_success
+  assert_output "3.10"
 
   n2st::set_which_python3_version
   assert_not_empty "$PYTHON3_VERSION"
-  # assert_equal "$PYTHON3_VERSION" "3.10" # Note: the container base image is "ubuntu:lates" -> the python verison will change
+  assert_equal "$PYTHON3_VERSION" "3.10"
 }
 
-@test "n2st::set_which_architecture_and_os ok" {
+# ....n2st::set_which_architecture_and_os..........................................................
+@test "n2st::set_which_architecture_and_os › darwin/arm64 case ok" {
+  function uname() {
+    # Mock uname command for darwin/arm64 case
+    case "$1" in
+    "-m")
+      echo "arm64"
+      return
+      ;;
+    *)
+      echo "Darwin"
+      return
+      ;;
+    esac
+  }
+  export -f uname
+
   run n2st::set_which_architecture_and_os
   assert_success
+  assert_output "darwin/arm64"
 
   n2st::set_which_architecture_and_os
   assert_not_empty "$IMAGE_ARCH_AND_OS"
+  assert_equal "$IMAGE_ARCH_AND_OS" "darwin/arm64"
+}
+
+@test "n2st::set_which_architecture_and_os › linux/x86 case ok" {
+  function uname() {
+    # Mock uname command for linux/x86_64 case
+    case "$1" in
+    "-m")
+      echo "x86_64"
+      return
+      ;;
+    *)
+      echo "Linux"
+      return
+      ;;
+    esac
+  }
+  export -f uname
+
+  run n2st::set_which_architecture_and_os
+  assert_success
+  assert_output "linux/x86"
+
+  n2st::set_which_architecture_and_os
+  assert_not_empty "$IMAGE_ARCH_AND_OS"
+  assert_equal "$IMAGE_ARCH_AND_OS" "linux/x86"
+}
+
+@test "n2st::set_which_architecture_and_os › linux/arm64 case ok" {
+  function uname() {
+    # Mock uname command for linux/arm64 case
+    case "$1" in
+    "-m")
+      echo "aarch64"
+      return
+      ;;
+    *)
+      echo "Linux"
+      return
+      ;;
+    esac
+  }
+  export -f uname
+
+  run n2st::set_which_architecture_and_os
+  assert_success
+  assert_output "linux/arm64"
+
+  n2st::set_which_architecture_and_os
+  assert_not_empty "$IMAGE_ARCH_AND_OS"
+  assert_equal "$IMAGE_ARCH_AND_OS" "linux/arm64"
+}
+
+@test "n2st::set_which_architecture_and_os › Jetson case ok" {
+  function uname() {
+    # Mock uname command for Jetson case
+    case "$1" in
+    "-m")
+      echo "aarch64"
+      return
+      ;;
+    "-r")
+      echo "tegra"
+      return
+      ;;
+    esac
+  }
+  export -f uname
+
+  run n2st::set_which_architecture_and_os
+  assert_success
+  assert_output "l4t/arm64"
+
+  n2st::set_which_architecture_and_os
+  assert_not_empty "$IMAGE_ARCH_AND_OS"
+  assert_equal "$IMAGE_ARCH_AND_OS" "l4t/arm64"
+}
+
+@test "n2st::set_which_architecture_and_os › Unsuported OS/aarch64 case expect failure" {
+  function uname() {
+    # Mock uname command for Unsuported OS/aarch64 case
+    case "$1" in
+    "-m")
+      echo "aarch64"
+      return
+      ;;
+    *)
+      echo "Window"
+      return
+      ;;
+    esac
+  }
+  export -f uname
+
+  run n2st::set_which_architecture_and_os
+  assert_failure
+  assert_output --partial "Unsupported OS for aarch64 processor"
+}
+
+@test "n2st::set_which_architecture_and_os › Unsuported ARCH case expect failure" {
+  function uname() {
+    # Mock uname command for Unsuported ARCH case
+    case "$1" in
+    "-m")
+      echo "unsuported_aarch"
+      return
+      ;;
+    *)
+      echo "Window"
+      return
+      ;;
+    esac
+  }
+  export -f uname
+
+  run n2st::set_which_architecture_and_os
+  assert_failure
+  assert_output --partial "Unsupported processor architecture"
 }
 
 # ====legacy API support testing===================================================================


### PR DESCRIPTION
# Description

This pull request includes the following updates to utility functions:

- Enhanced error handling for `n2st::set_which_architecture_and_os` with refined messages and return statements.
- Added mock-based unit tests for `n2st::set_which_architecture_and_os` and `n2st::set_which_python3_version`, covering multiple edge cases.
- Updated examples in the documentation to reflect consistent variable referencing styles such as `$PYTHON3_VERSION` and `$IMAGE_ARCH_AND_OS`.
- Modified utility functions to print relevant environment variables (e.g., Python version, architecture, and OS) to stdout for easier debugging.
- Simplified conditional logic, ensuring compatibility across supported architectures and OSes.

These changes improve the robustness, clarity, and usability of the utility functions.

# Checklist:

### Code related
- [x] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [x] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)


 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_