### PR TITLE
Ensure DOCKER_EXIT_CODE is returned in docker utility function

### DIFF
--- a/src/function_library/docker_utilities.bash
+++ b/src/function_library/docker_utilities.bash
@@ -89,7 +89,9 @@ function n2st::show_and_execute_docker() {
 
   fi
 
+  # Note: keep DOCKER_EXIT_CODE for retro compatibility
   export DOCKER_EXIT_CODE
+  return $DOCKER_EXIT_CODE
 }
 
 

--- a/tests/test_docker_utilities.bats
+++ b/tests/test_docker_utilities.bats
@@ -114,7 +114,7 @@ teardown() {
   mock_docker_command_exit_error
   assert_exist "/.dockerenv"
   run n2st::show_and_execute_docker "${DOCKER_CMD}" true
-  assert_success
+  assert_failure
   assert_output --regexp "\]".*"Execute command".*"docker".*"${DOCKER_CMD}".*
   assert_output --regexp "\#\#teamcity\[message text='".*"\|\]".*"Command".*"docker".*"${DOCKER_CMD}".*"exited with error \(DOCKER_EXIT_CODE=1\)\!".*"' errorDetails='1' status='ERROR'\]"
 #  bats_print_run_env_variable
@@ -125,7 +125,7 @@ teardown() {
   mock_docker_command_exit_error
   assert_exist "/.dockerenv"
   run n2st::show_and_execute_docker "${DOCKER_CMD}" true
-  assert_success
+  assert_failure
   assert_output --regexp "\]".*"Execute command".*"docker".*"${DOCKER_CMD}".*
   assert_output --regexp .*"\]".*"Command".*"docker".*"${DOCKER_CMD}".*"exited with error \(DOCKER_EXIT_CODE=1\)\!".*
 #  bats_print_run_env_variable


### PR DESCRIPTION
# Description

This pull request updates the `n2st::show_and_execute_docker` function to explicitly return the `DOCKER_EXIT_CODE` variable value. This change ensures compatibility and correctness of the function. Additionally, test cases have been updated to assert failure on error conditions, providing better validation.
