### PR TITLE
Unify string quoting style in Bash scripts

### DIFF
--- a/src/function_library/terminal_splash.bash
+++ b/src/function_library/terminal_splash.bash
@@ -294,8 +294,8 @@ function n2st::echo_centering_str() {
 #
 # =================================================================================================
 function n2st::snow_splash() {
-  local title=${1:-'NorLab'}
-  local optional_url=${2:-'https://github.com/norlab-ulaval'}
+  local title=${1:-"NorLab"}
+  local optional_url=${2:-"https://github.com/norlab-ulaval"}
 
   # Formatting
   #   - 1=Bold/bright
@@ -375,8 +375,8 @@ function n2st::snow_splash() {
 #
 # =================================================================================================
 function n2st::norlab_splash() {
-  local title=${1:-'NorLab'}
-  local optional_url=${2:-'https://github.com/norlab-ulaval'}
+  local title=${1:-"NorLab"}
+  local optional_url=${2:-"https://github.com/norlab-ulaval"}
   local splash_type=${3:-negative} # Option: small, negative or big
 
 

--- a/tests/bats_testing_tools/run_bats_tests_in_docker.bash
+++ b/tests/bats_testing_tools/run_bats_tests_in_docker.bash
@@ -85,8 +85,8 @@ while [ $# -gt 0 ]; do
 done
 
 # ....Set env variables (post cli)...............................................................
-RUN_TESTS_IN_DIR=${REMAINING_ARGS[0]:-'tests'}
-BATS_DOCKERFILE_DISTRO=${REMAINING_ARGS[1]:-'ubuntu'}
+RUN_TESTS_IN_DIR=${REMAINING_ARGS[0]:-"tests"}
+BATS_DOCKERFILE_DISTRO=${REMAINING_ARGS[1]:-"ubuntu"}
 
 
 # ....Project root logic...........................................................................


### PR DESCRIPTION
# Description

Revised Bash scripts to adopt consistent string quoting by replacing single quotes with double quotes in variable default assignments. This update enhances readability and maintainability across `terminal_splash.bash` and `run_bats_tests_in_docker.bash`.  
