### PR TITLE
Fix fallback value syntax for exit code in test script

### DIFF
--- a/tests/tests_template/run_bats_core_test_in_n2st.bash
+++ b/tests/tests_template/run_bats_core_test_in_n2st.bash
@@ -47,7 +47,7 @@ function n2st::bats_tests_teardown_callback() {
   exit_code=$?
   cd "${superproject_path:?err}" || exit 1
   # Add any teardown logic here
-  exit ${exit_code:1}
+  exit ${exit_code:-1}
 }
 trap n2st::bats_tests_teardown_callback EXIT
 


### PR DESCRIPTION
# Description

Corrected the fallback value syntax for the `exit_code` variable in the `run_bats_core_test_in_n2st.bash` script. The change ensures that an appropriate default value of `-1` is used when `exit_code` is unset, preventing potential script failures.
