### PR TITLE
Fix prompt style compatibility for light and dark backgrounds

### DIFF
--- a/src/function_library/.env.msg_style
+++ b/src/function_library/.env.msg_style
@@ -17,18 +17,18 @@ MSG_PROMPT_NAME="${PROJECT_PROMPT_NAME:-${PROJECT_GIT_NAME:?'ERROR: set PROJECT_
 #
 # Terminal print version
 #
-#MSG_EMPH_FORMAT="\033[0;37m"
-MSG_EMPH_FORMAT="\033[1;97m"
+MSG_EMPH_FORMAT="\033[1m"
+MSG_HIGHLIGHT_FORMAT="\033[7m"
 MSG_DIMMED_FORMAT="\033[1;2m"
-MSG_BASE_FORMAT="\033[1m"
-MSG_ERROR_FORMAT="\033[1;31m"
+MSG_BASE_FORMAT="\033[1;39m" # bold+default foreground
+MSG_ERROR_FORMAT="\033[7;31m"
 MSG_DONE_FORMAT="\033[1;32m"
-MSG_WARNING_FORMAT="\033[1;33m"
+MSG_WARNING_FORMAT="\033[7;33m"
+MSG_BLINK_FORMAT="\033[5m"
 MSG_END_FORMAT="\033[0m"
 
-MSG_AWAITING_INPUT="${MSG_BASE_FORMAT}[${MSG_PROMPT_NAME} awaiting input]${MSG_END_FORMAT}"
+MSG_AWAITING_INPUT="${MSG_BLINK_FORMAT}[${MSG_PROMPT_NAME} awaiting input]${MSG_END_FORMAT}"
 MSG_BASE="${MSG_BASE_FORMAT}[${MSG_PROMPT_NAME}]${MSG_END_FORMAT}"
-#MSG_DONE="\033[1;32m[${MSG_PROMPT_NAME} done]${MSG_END_FORMAT}"
 MSG_DONE="${MSG_DONE_FORMAT}[${MSG_PROMPT_NAME} done]${MSG_END_FORMAT}"
 MSG_WARNING="${MSG_WARNING_FORMAT}[${MSG_PROMPT_NAME} warning]${MSG_END_FORMAT}"
 MSG_ERROR="${MSG_ERROR_FORMAT}[${MSG_PROMPT_NAME} error]${MSG_END_FORMAT}"
@@ -64,13 +64,14 @@ MSG_LINE_CHAR_TEST=' '
 #   - ASCII art generated using image generator at https://asciiart.club
 #
 # Foreground colors
-#   - 2=Dim
 #   - 37=light gray
 #   - 90=dark gray
 #   - 30=black
 #   - 97=white
+#   - 39=default foreground
 # Formatting
 #   - 1=Bold/bright
 #   - 2=Dim
-#   - 4=underline
+#   - 4=Underline
+#   - 7=Swaps foreground and background colors
 # ================================

--- a/src/function_library/prompt_utilities.bash
+++ b/src/function_library/prompt_utilities.bash
@@ -105,7 +105,7 @@ function n2st::print_msg_error_and_exit() {
   local error_msg=$1
 
   echo ""
-  echo -e "${MSG_ERROR}: ${error_msg}" 1>&2
+  echo -e "${MSG_ERROR} ${error_msg}" 1>&2
   # Note: The >&2 sends the echo output to standard error
   echo "Exiting now."
   echo ""
@@ -116,7 +116,7 @@ function n2st::print_msg_error_and_return() {
   local error_msg=$1
 
   echo ""
-  echo -e "${MSG_ERROR}: ${error_msg}" 1>&2
+  echo -e "${MSG_ERROR} ${error_msg}" 1>&2
   # Note: The >&2 sends the echo output to standard error
   echo "Exiting function now."
   echo ""
@@ -126,7 +126,7 @@ function n2st::print_msg_error_and_return() {
 function n2st::print_msg_error() {
   local error_msg=$1
 
-  echo -e "${MSG_ERROR}: ${error_msg}" 1>&2
+  echo -e "${MSG_ERROR} ${error_msg}" 1>&2
 }
 
 function n2st::print_msg_error_vspaced() {
@@ -134,7 +134,7 @@ function n2st::print_msg_error_vspaced() {
   local error_msg=$1
 
   echo ""
-  echo -e "${MSG_ERROR}: ${error_msg}" 1>&2
+  echo -e "${MSG_ERROR} ${error_msg}" 1>&2
   echo ""
 }
 

--- a/tests/prompt_interactive_visualization.bash
+++ b/tests/prompt_interactive_visualization.bash
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+N2ST_ROOT="$( git rev-parse --show-toplevel )"
+cd "${N2ST_ROOT}" || exit 1
+source import_norlab_shell_script_tools_lib.bash
+
+n2st::norlab_splash "The title" "https://the_url"
+
+n2st::print_formated_script_header "$(basename "$0")" "${MSG_LINE_CHAR_BUILDER_LVL1}"
+
+echo -e "
+Terminal styles
+
+  ${MSG_EMPH_FORMAT}MSG_EMPH_FORMAT${MSG_END_FORMAT}
+  ${MSG_HIGHLIGHT_FORMAT}MSG_HIGHLIGHT_FORMAT${MSG_END_FORMAT}
+  ${MSG_DIMMED_FORMAT}MSG_DIMMED_FORMAT${MSG_END_FORMAT}
+  ${MSG_BASE_FORMAT}MSG_BASE_FORMAT${MSG_END_FORMAT}
+  ${MSG_ERROR_FORMAT}MSG_ERROR_FORMAT${MSG_END_FORMAT}
+  ${MSG_DONE_FORMAT}MSG_DONE_FORMAT${MSG_END_FORMAT}
+  ${MSG_WARNING_FORMAT}MSG_WARNING_FORMAT${MSG_END_FORMAT}
+"
+
+echo -e "Example
+
+${MSG_EMPH_FORMAT}Lorem ipsum dolor sit amet${MSG_END_FORMAT}, consectetur adipiscing elit. Nam in egestas magna, vel molestie mauris. Sed vehicula felis at felis posuere efficitur quis sit amet arcu. ${MSG_DIMMED_FORMAT}Proin egestas urna vulputate lorem pharetra, in posuere ipsum posuere.${MSG_END_FORMAT} Fusce condimentum mi, ${MSG_HIGHLIGHT_FORMAT}non euismod${MSG_END_FORMAT} quam fermentumet urna aliquam.
+"
+
+n2st::draw_horizontal_line_across_the_terminal_window "."
+echo -e "
+n2st::print_msg functions
+"
+
+n2st::print_msg "The message"
+n2st::print_msg_done "The message"
+n2st::print_msg_warning "The message"
+n2st::print_msg_awaiting_input "The message"
+n2st::print_msg_error "The message"
+echo
+
+n2st::draw_horizontal_line_across_the_terminal_window "."
+echo -e "
+MSG_LINE_CHAR styles
+
+  MSG_LINE_CHAR_BUILDER_LVL1: $MSG_LINE_CHAR_BUILDER_LVL1
+  MSG_LINE_CHAR_BUILDER_LVL2: $MSG_LINE_CHAR_BUILDER_LVL2
+  MSG_LINE_CHAR_INSTALLER: $MSG_LINE_CHAR_INSTALLER
+  MSG_LINE_CHAR_UTIL: $MSG_LINE_CHAR_UTIL
+  MSG_LINE_CHAR_TEST: $MSG_LINE_CHAR_TEST
+"
+
+n2st::draw_horizontal_line_across_the_terminal_window "$MSG_LINE_CHAR_BUILDER_LVL1"
+n2st::draw_horizontal_line_across_the_terminal_window "$MSG_LINE_CHAR_BUILDER_LVL2"
+n2st::draw_horizontal_line_across_the_terminal_window "$MSG_LINE_CHAR_INSTALLER"
+n2st::draw_horizontal_line_across_the_terminal_window "$MSG_LINE_CHAR_UTIL"
+n2st::draw_horizontal_line_across_the_terminal_window "$MSG_LINE_CHAR_TEST"
+
+
+n2st::print_formated_script_footer "$(basename "$0")" "${MSG_LINE_CHAR_BUILDER_LVL1}"
+
+
+
+
+

--- a/tests/test_dotenv_files.bats
+++ b/tests/test_dotenv_files.bats
@@ -121,6 +121,7 @@ function source_dotenv_project() {
 
   # ....Tests......................................................................................
   assert_not_empty "${MSG_EMPH_FORMAT}"
+  assert_not_empty "${MSG_HIGHLIGHT_FORMAT}"
   assert_not_empty "${MSG_DIMMED_FORMAT}"
   assert_not_empty "${MSG_BASE_FORMAT}"
   assert_not_empty "${MSG_ERROR_FORMAT}"
@@ -147,6 +148,7 @@ function source_dotenv_project() {
   # shellcheck disable=SC2125
   local ESCAPE_CHAR="\033\[".*
   assert_regex "${MSG_EMPH_FORMAT}" "${ESCAPE_CHAR}"
+  assert_regex "${MSG_HIGHLIGHT_FORMAT}" "${ESCAPE_CHAR}"
   assert_regex "${MSG_DIMMED_FORMAT}" "${ESCAPE_CHAR}"
   assert_regex "${MSG_BASE_FORMAT}" "${ESCAPE_CHAR}"
   assert_regex "${MSG_ERROR_FORMAT}" "${ESCAPE_CHAR}"


### PR DESCRIPTION
# Description

- Fixed an issue where emphasized string formats disappeared in day mode.
- Introduced `prompt_interactive_visualization.bash` to interactively showcase terminal styles and message formats.
- Updated `prompt_utilities.bash` to remove unnecessary colons in error messages for consistent formatting.
- Extended `.env.msg_style` with new styles (e.g., highlight, blink) and adjusted existing ones for improved clarity.
- Enhanced dotenv tests to validate the new `MSG_HIGHLIGHT_FORMAT`.

# Checklist:

### Code related
- [x] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [x] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)


 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_